### PR TITLE
docs(cli): add links back to oclif's testing tools

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -103,3 +103,7 @@ DESCRIPTION
 _See code: [src/commands/init.js](https://github.com/spaship/cli/blob/v0.3.4/src/commands/init.js)_
 
 <!-- commandsstop -->
+
+# Writing tests
+
+Tests are written using oclif's testing tools. See [oclif's testing documentation](https://oclif.io/docs/testing) for more.

--- a/packages/cli/test/commands/deploy.test.js
+++ b/packages/cli/test/commands/deploy.test.js
@@ -1,3 +1,6 @@
+// This test file uses oclif's testing tools.
+// See: https://oclif.io/docs/testing
+
 const { expect, test } = require("@oclif/test");
 
 describe("deploy", () => {

--- a/packages/cli/test/commands/init.test.js
+++ b/packages/cli/test/commands/init.test.js
@@ -1,3 +1,6 @@
+// This test file uses oclif's testing tools.
+// See: https://oclif.io/docs/testing
+
 const { expect, test } = require("@oclif/test");
 const fsp = require("fs").promises;
 


### PR DESCRIPTION
This adds some links from the cli package's README and test files that point back to oclif's testing documentation.
This is to help prevent any confusion about how to write the tests.  Such confusion would be understandable because the
cli uses a different testing system than the rest of the packages.