### PR TITLE
add a mongo database with apikey helpers

### DIFF
--- a/packages/sync-service/.gitignore
+++ b/packages/sync-service/.gitignore
@@ -65,3 +65,5 @@ config.json
 
 # webstorm
 .idea
+
+mongo-db.js

--- a/packages/sync-service/README.md
+++ b/packages/sync-service/README.md
@@ -39,15 +39,21 @@ When your pull request is merged, "squash and merge" should be used, and a Conve
 
 Configuration can be provided by CLI flags, environment variables, or a configuration file. Arguments are processed in that order, so CLI flags take precedence over environment variables, which take precedence over the configuration file.
 
-| Option          | Description                       | CLI             | Env                   | config.json    | Default                |
-| --------------- | --------------------------------- | --------------- | --------------------- | -------------- | ---------------------- |
-| **config file** | Where to find the config file.    | `--config-file` | `SPASHIP_CONFIG_FILE` | N/A            | none                |
-| **upload dir**  | Directory to upload SPA archives. | `--upload-dir`  | `SPASHIP_UPLOAD_DIR`  | `"upload_dir"` | `/tmp/spaship_uploads` |
-| **webroot**     | Directory to extract/deploy SPAs. | `--webroot`     | `SPASHIP_WEBROOT`     | `"webroot"`    | `/var/www`             |
-| **host**        | Hostname to run on.               | `--host`        | `SPASHIP_HOST`        | `"host"`       | `localhost`            |
-| **port**        | Port to run on.                   | `--port`        | `SPASHIP_PORT`        | `"port"`       | `8008`                 |
+| Option          | Description                                                                                | CLI             | Env                   | config.json    | Default                                        |
+| --------------- | ------------------------------------------------------------------------------------------ | --------------- | --------------------- | -------------- | ---------------------------------------------- |
+| **config file** | Where to find the config file.                                                             | `--config-file` | `SPASHIP_CONFIG_FILE` | N/A            | none                                           |
+| **upload dir**  | Directory to upload SPA archives.                                                          | `--upload-dir`  | `SPASHIP_UPLOAD_DIR`  | `"upload_dir"` | `/tmp/spaship_uploads`                         |
+| **webroot**     | Directory to extract/deploy SPAs.                                                          | `--webroot`     | `SPASHIP_WEBROOT`     | `"webroot"`    | `/var/www`                                     |
+| **host**        | Hostname to run on.                                                                        | `--host`        | `SPASHIP_HOST`        | `"host"`       | `localhost`                                    |
+| **port**        | Port to run on.                                                                            | `--port`        | `SPASHIP_PORT`        | `"port"`       | `8008`                                         |
+| **mongo_url**   | The base URL of your mongodb instance.                                                     | `--mongo-url`   | `SPASHIP_MONGO_URL`   | `"mongo_url"`  | `"mongodb://localhost:27017"`                  |
+| **mongo_db**    | The mongodb database name.                                                                 | `--mongo-db`    | `SPASHIP_MONGO_DB`    | `"mongo_db"`   | `"spaship"`                                    |
+| **mock_db**     | Whether to use a mock database ([mongo-mock](https://github.com/williamkapke/mongo-mock)). | `--mock-db`     | `SPASHIP_MOCK_DB`     | `"mock_db"`    | `true`, except when `NODE_ENV == "production"` |
+| **no_mock_db**  | Disable mock database. Overrides `mock_db`.                                                | `--no-mock-db`  | `SPASHIP_NO_MOCK_DB`  | `"no_mock_db"` | `false`                                        |
 
 **Note** about the filepath configurations, `config file`, `upload dir`, and `webroot`: they must be absolute paths when defined in an environment variable or config file. When defined in CLI options like, they can be written relative to CWD. Example: `--config-file=./config.json`
+
+**Note:** When `mock_db` is on, the mocked database will be persisted as a flat file named `mock-db.js` right here in the same directory as this README.
 
 ### SPA metadata
 

--- a/packages/sync-service/README.md
+++ b/packages/sync-service/README.md
@@ -49,7 +49,6 @@ Configuration can be provided by CLI flags, environment variables, or a configur
 | **mongo_url**   | The base URL of your mongodb instance.                                                     | `--mongo-url`   | `SPASHIP_MONGO_URL`   | `"mongo_url"`  | `"mongodb://localhost:27017"`                  |
 | **mongo_db**    | The mongodb database name.                                                                 | `--mongo-db`    | `SPASHIP_MONGO_DB`    | `"mongo_db"`   | `"spaship"`                                    |
 | **mock_db**     | Whether to use a mock database ([mongo-mock](https://github.com/williamkapke/mongo-mock)). | `--mock-db`     | `SPASHIP_MOCK_DB`     | `"mock_db"`    | `true`, except when `NODE_ENV == "production"` |
-| **no_mock_db**  | Disable mock database. Overrides `mock_db`.                                                | `--no-mock-db`  | `SPASHIP_NO_MOCK_DB`  | `"no_mock_db"` | `false`                                        |
 
 **Note** about the filepath configurations, `config file`, `upload dir`, and `webroot`: they must be absolute paths when defined in an environment variable or config file. When defined in CLI options like, they can be written relative to CWD. Example: `--config-file=./config.json`
 

--- a/packages/sync-service/config.js
+++ b/packages/sync-service/config.js
@@ -7,14 +7,7 @@ function rel2abs(p) {
   return path.resolve(process.cwd(), p);
 }
 
-const validOptions = [
-  "config_file",
-  "upload_dir",
-  "webroot",
-  "host",
-  "port",
-  "autosync"
-];
+const validOptions = ["config_file", "upload_dir", "webroot", "host", "port", "autosync", "mongo_url", "mock_db"];
 const filepathOptions = ["config_file", "upload_dir", "webroot"]; // config options that represent filepaths
 
 // Read CLI flags first, then environment variables (argv).
@@ -64,7 +57,10 @@ nconf.defaults({
   port: 8008,
   host: "localhost",
   webroot: "/var/www",
-  upload_dir: "/tmp/spaship_uploads"
+  upload_dir: "/tmp/spaship_uploads",
+  mongo_url: "mongodb://localhost:27017",
+  mongo_db: "spaship",
+  mock_db: process.env.NODE_ENV !== "production" // use a mock database by default in dev environments
 });
 
 module.exports = nconf;

--- a/packages/sync-service/lib/db.apikey.js
+++ b/packages/sync-service/lib/db.apikey.js
@@ -1,0 +1,35 @@
+const db = require("./db");
+const shortid = require("shortid");
+
+async function attach() {
+  const apikeys = await db.connect("apikeys");
+
+  async function createKey(userid = null) {
+    const apikey = shortid.generate();
+    const doc = { userid, apikey };
+    await apikeys.insertOne(doc);
+    return doc;
+  }
+
+  async function deleteKey(apikey) {
+    await apikeys.deleteMany({ apikey });
+  }
+
+  async function getKeysByUser(userid, limit = 100) {
+    return await apikeys
+      .find({ userid })
+      .limit(limit)
+      .toArray();
+  }
+
+  async function getUserByKey(apikey, limit = 100) {
+    return await apikeys
+      .find({ apikey })
+      .limit(limit)
+      .toArray();
+  }
+
+  return { getKeysByUser, getUserByKey, createKey, deleteKey };
+}
+
+module.exports = { attach };

--- a/packages/sync-service/lib/db.apikey.test.js
+++ b/packages/sync-service/lib/db.apikey.test.js
@@ -1,0 +1,94 @@
+const shortid = require("shortid");
+const mockfs = require("mock-fs");
+const db_apikey = require("./db.apikey");
+const config = require("../config");
+
+// make shortid non-random while testing
+jest.mock("shortid");
+shortid.generate.mockResolvedValue("MOCK_KEY");
+
+// override some configuration values
+config.get = jest.fn(opt => {
+  const fakeConfig = {
+    webroot: "/fake/webroot"
+  };
+  return fakeConfig[opt];
+});
+
+// this is needed to allow console to continue working while the fs is mocked
+global.console = require("../../../__mocks__/console");
+
+describe("sync-service.db.apikey", () => {
+  beforeEach(() => {
+    mockfs({});
+  });
+  afterEach(() => {
+    mockfs.restore();
+  });
+
+  describe("attach", () => {
+    test("should be able to attach to the collection", async () => {
+      const apikeys = await db_apikey.attach();
+      expect(apikeys).toBeDefined();
+    });
+  });
+  describe("apikey CRUD", () => {
+    test("should be able to create a new api key", async () => {
+      const apikeys = await db_apikey.attach();
+
+      // special mock key for this test
+      shortid.generate.mockReturnValueOnce("fake.key");
+
+      const doc = await apikeys.createKey("fake.name");
+
+      expect(doc).toEqual({ userid: "fake.name", apikey: "fake.key" });
+    });
+
+    test("should be able to get api keys by userid", async () => {
+      const apikeys = await db_apikey.attach();
+      const userid = "bigbadogre";
+      const apikey = "853626948149";
+
+      // special mock key for this test
+      shortid.generate.mockReturnValueOnce(apikey);
+
+      await apikeys.createKey(userid);
+
+      const doc = await apikeys.getKeysByUser(userid);
+      expect(doc).toMatchObject([{ userid, apikey }]);
+    });
+
+    test("should be able to get userid by apikey", async () => {
+      const apikeys = await db_apikey.attach();
+      const userid = "babyyoda";
+      const apikey = "018265271839";
+
+      // special mock key for this test
+      shortid.generate.mockReturnValueOnce(apikey);
+
+      await apikeys.createKey(userid);
+
+      const doc = await apikeys.getUserByKey(apikey);
+      expect(doc).toMatchObject([{ userid, apikey }]);
+    });
+
+    test("should be able to delete a key", async () => {
+      const apikeys = await db_apikey.attach();
+      const userid = "babyyoda";
+      const apikey = "018265271839";
+
+      // special mock key for this test
+      shortid.generate.mockReturnValueOnce(apikey);
+
+      // create key, delete it, then check for its existance
+
+      await apikeys.createKey(userid);
+
+      await apikeys.deleteKey(apikey);
+
+      const doc = await apikeys.getUserByKey(apikey);
+      expect(doc).not.toMatchObject([{ userid, apikey }]);
+    });
+    // return { getKeysByUser, getUserByKey, createKey, deleteKey };
+  });
+});

--- a/packages/sync-service/lib/db.js
+++ b/packages/sync-service/lib/db.js
@@ -1,0 +1,34 @@
+/**
+ * @see http://mongodb.github.io/node-mongodb-native/3.5/reference/ecmascriptnext/crud
+ */
+
+const config = require("../config");
+
+const mongoPkg = config.get("mock_db") ? "mongo-mock" : "mongodb";
+
+const mongodb = require(mongoPkg);
+mongodb.max_delay = 0; //you can choose to NOT pretend to be async (default is 400ms)
+const MongoClient = mongodb.MongoClient;
+MongoClient.persist = "mock-db.js"; //persist the data to disk
+
+// Connection URL
+
+let url = `${config.get("mongo_url")}/${config.get("mongo_db")}`;
+
+let reusableClient;
+
+async function connect(collectionName) {
+  if (!collectionName) {
+    throw new Error("db.connect must be given a collection name");
+  }
+  // if a connection is already open, use it
+  if (reusableClient) {
+    return reusableClient.collection(collectionName);
+  }
+
+  // otherwise, connect
+  reusableClient = await MongoClient.connect(url, {});
+  return reusableClient.collection(collectionName);
+}
+
+module.exports = { connect };

--- a/packages/sync-service/package-lock.json
+++ b/packages/sync-service/package-lock.json
@@ -120,6 +120,17 @@
         "concat-map": "0.0.1"
       }
     },
+    "bson": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.3.tgz",
+      "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg=="
+    },
+    "bson-objectid": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bson-objectid/-/bson-objectid-1.3.0.tgz",
+      "integrity": "sha512-YcB+lRJEEEIcHNLKyhmHujW7OCVE3+xr9IpEhlprBZnXgF3hqeePeexIsAaOtu1SbkgZRlJVUxvYZ3ngUOyIew==",
+      "dev": true
+    },
     "buffer": {
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
@@ -214,6 +225,12 @@
         "strip-ansi": "^3.0.1",
         "wrap-ansi": "^2.0.0"
       }
+    },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -424,15 +441,43 @@
         }
       }
     },
+    "deep-equal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "dev": true,
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
+    },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "denque": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
+      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
     },
     "depd": {
       "version": "1.1.2",
@@ -497,6 +542,36 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "es-abstract": {
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.2.tgz",
+      "integrity": "sha512-YoKuru3Lyoy7yVTBSH2j7UxTqe/je3dWAruC0sHvZX1GNd5zX8SSLvQqEgO9b3Ex8IW+goFI9arEEsFIbulhOw==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "escape-html": {
@@ -644,6 +719,12 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
     "gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -690,6 +771,21 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "dev": true
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -765,6 +861,24 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
       "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
     },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "dev": true
+    },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -778,10 +892,28 @@
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
       "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
     },
+    "is-regex": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
     },
     "isarray": {
       "version": "1.0.0",
@@ -831,6 +963,12 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -898,6 +1036,71 @@
         "minimist": "0.0.8"
       }
     },
+    "modifyjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/modifyjs/-/modifyjs-0.3.1.tgz",
+      "integrity": "sha1-ckaUd/tMRwlx1hemO6G73pqqx88=",
+      "dev": true,
+      "requires": {
+        "clone": "^2.1.1",
+        "deep-equal": "^1.0.1"
+      }
+    },
+    "mongo-mock": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/mongo-mock/-/mongo-mock-3.8.1.tgz",
+      "integrity": "sha512-qEgP3zahEwhgI1JfRhvi/wdW9Ff2GwQv+H0Ia7Dwa70Tn9lckwbAtRT1KXfYNZe8H7A5hC3WV+gDAtU3yhJRbw==",
+      "dev": true,
+      "requires": {
+        "bson-objectid": "^1.2.5",
+        "debug": "^2.6.9",
+        "lodash": "^4.17.13",
+        "modifyjs": "^0.3.1",
+        "object-assign-deep": "^0.4.0",
+        "sift": "^3.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "mongodb": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.0.tgz",
+      "integrity": "sha512-M1usRxQ/Xl/IZuTK4LJXViwzaGkH1CuccH4iXqK46+Nv25Y7bAIawoxEZQBAlMtLQhRKyEzVoBK0NBTY01Zp5Q==",
+      "requires": {
+        "bl": "^2.2.0",
+        "bson": "^1.1.1",
+        "denque": "^1.4.1",
+        "require_optional": "^1.0.1",
+        "safe-buffer": "^5.1.2",
+        "saslprep": "^1.0.0"
+      },
+      "dependencies": {
+        "bl": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
+          "integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
+          "requires": {
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
+          }
+        }
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -927,6 +1130,11 @@
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+    },
+    "nanoid": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.9.tgz",
+      "integrity": "sha512-J2X7aUpdmTlkAuSe9WaQ5DsTZZPW1r/zmEWKsGhbADO6Gm9FMd2ZzJ8NhsmP4OtA9oFhXfxNqPlreHEDOGB4sg=="
     },
     "nconf": {
       "version": "0.10.0",
@@ -1032,6 +1240,42 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-assign-deep": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-assign-deep/-/object-assign-deep-0.4.0.tgz",
+      "integrity": "sha512-54Uvn3s+4A/cMWx9tlRez1qtc7pN7pbQ+Yi7mjLjcBpWLlP+XbSHiHbQW6CElDiV4OvuzqnMrBdkgxI1mT8V/Q==",
+      "dev": true
+    },
+    "object-inspect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "dev": true
+    },
+    "object-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
+      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
     },
     "on-finished": {
       "version": "2.3.0",
@@ -1188,6 +1432,30 @@
         }
       }
     },
+    "regexp.prototype.flags": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      }
+    },
+    "require_optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "requires": {
+        "resolve-from": "^2.0.0",
+        "semver": "^5.1.0"
+      }
+    },
+    "resolve-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+    },
     "rimraf": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -1205,6 +1473,15 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
     },
     "sax": {
       "version": "1.2.4",
@@ -1292,10 +1569,33 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
+    "shortid": {
+      "version": "2.2.15",
+      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.15.tgz",
+      "integrity": "sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==",
+      "requires": {
+        "nanoid": "^2.1.0"
+      }
+    },
+    "sift": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-3.3.12.tgz",
+      "integrity": "sha1-T1zfFq89syr6BKslKXsOIK2YKUo=",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "optional": true,
+      "requires": {
+        "memory-pager": "^1.0.2"
+      }
     },
     "statuses": {
       "version": "1.5.0",
@@ -1315,6 +1615,26 @@
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
         "strip-ansi": "^3.0.0"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "string_decoder": {

--- a/packages/sync-service/package.json
+++ b/packages/sync-service/package.json
@@ -33,14 +33,19 @@
     "decompress-tarxz": "^3.0.0",
     "express": "^4.17.1",
     "lodash": "^4.17.15",
+    "mongodb": "^3.5.0",
     "ms": "^2.1.2",
     "multer": "^1.4.2",
     "mvdir": "^1.0.5",
     "nconf": "^0.10.0",
+    "shortid": "^2.2.15",
     "tmp-promise": "^2.0.2",
     "url-join": "^4.0.1"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "mongo-mock": "^3.8.1"
   }
 }


### PR DESCRIPTION
I was eager to work on the database and API key features so I put together this PR.

It adds:

 1. a new module, `sync-service/lib/db` which creates a connection to a mongodb database
 2. a new module, `sync-service/lib/db.apikey` which connects to a collection named "apikeys" in the database
 3. handy CRUD functions for API keys: `getKeysByUser, getUserByKey, createKey, deleteKey`
 4. tests for the `db.apikey` module (`db` should get some too, I just didn't have the time tonight)
 5. the [mongo-mock](https://github.com/williamkapke/mongo-mock) module to use during development.  It creates an
    in-memory mongo mock so nobody has to set up a real mongodb in their dev environments.  It's extremely convenient.
 6. configuration properties for each of these features (see README)