### PR TITLE
fix(api): fix connection to mongodb

### DIFF
--- a/packages/api/lib/db.js
+++ b/packages/api/lib/db.js
@@ -4,36 +4,8 @@
 
 const config = require("../config");
 
-const mongoPkg = config.get("mock_db") ? "mongo-mock" : "mongodb";
-
-const mongodb = require(mongoPkg);
-mongodb.max_delay = 0; //you can choose to NOT pretend to be async (default is 400ms)
-const MongoClient = mongodb.MongoClient;
-MongoClient.persist = "mock-db.js"; //persist the data to disk
-
-// Connection URL
-const connectUrls = ["mongodb://"];
-if (config.get("mongo_user") && config.get("mongo_password")) {
-  connectUrls.push(`${config.get("mongo_user")}:${config.get("mongo_password")}@`);
+if (config.get("mock_db")) {
+  module.exports = require("./db.mock-mongo.js");
+} else {
+  module.exports = require("./db.real-mongo.js");
 }
-connectUrls.push(config.get("mongo_url"));
-connectUrls.push(`/${config.get("mongo_db")}`);
-const url = connectUrls.join("");
-
-let reusableClient;
-
-async function connect(collectionName) {
-  if (!collectionName) {
-    throw new Error("db.connect must be given a collection name");
-  }
-  // if a connection is already open, use it
-  if (reusableClient) {
-    return reusableClient.collection(collectionName);
-  }
-
-  // otherwise, connect
-  reusableClient = await MongoClient.connect(url, {});
-  return reusableClient.collection(collectionName);
-}
-
-module.exports = { connect };

--- a/packages/api/lib/db.mock-mongo.js
+++ b/packages/api/lib/db.mock-mongo.js
@@ -1,0 +1,34 @@
+// if we're using a mocked mongodb...
+const config = require("../config");
+
+const mongodb = require("mongo-mock");
+mongodb.max_delay = 0; //you can choose to NOT pretend to be async (default is 400ms)
+const MongoClient = mongodb.MongoClient;
+MongoClient.persist = "mock-db.js"; //persist the data to disk
+
+// Connection URL
+const connectUrls = ["mongodb://"];
+if (config.get("mongo_user") && config.get("mongo_password")) {
+  connectUrls.push(`${config.get("mongo_user")}:${config.get("mongo_password")}@`);
+}
+connectUrls.push(config.get("mongo_url"));
+connectUrls.push(`/${config.get("mongo_db")}`);
+const url = connectUrls.join("");
+
+let reusableClient;
+
+async function connect(collectionName) {
+  if (!collectionName) {
+    throw new Error("db.connect must be given a collection name");
+  }
+  // if a connection is already open, use it
+  if (reusableClient) {
+    return reusableClient.collection(collectionName);
+  }
+
+  // otherwise, connect
+  reusableClient = await MongoClient.connect(url, {});
+  return reusableClient.collection(collectionName);
+}
+
+module.exports = { connect };

--- a/packages/api/lib/db.real-mongo.js
+++ b/packages/api/lib/db.real-mongo.js
@@ -1,0 +1,35 @@
+const config = require("../config");
+const { log } = require("@spaship/common/lib/logging/pino");
+const mongodb = require("mongodb");
+
+// Connection URL
+const connectUrls = ["mongodb://"];
+if (config.get("mongo_user") && config.get("mongo_password")) {
+  connectUrls.push(`${config.get("mongo_user")}:${config.get("mongo_password")}@`);
+}
+connectUrls.push(config.get("mongo_url"));
+// connectUrls.push(`/${config.get("mongo_db")}`);
+const url = connectUrls.join("");
+
+log.info(`connecting to ${url}`);
+
+const client = new mongodb.MongoClient(url, { useUnifiedTopology: true });
+
+let reusableClient;
+
+async function connect(collectionName) {
+  if (!collectionName) {
+    throw new Error("db.connect must be given a collection name");
+  }
+
+  // if a connection is already open, use it
+  if (!reusableClient) {
+    reusableClient = await client.connect();
+  }
+
+  // otherwise, connect
+  let db = reusableClient.db(config.get("mongo_db"));
+  return db.collection(collectionName);
+}
+
+module.exports = { connect };


### PR DESCRIPTION
The code to connect to (real) mongodb was broken and the SPAship API only worked in "mocked mongodb" mode.  This fixes
the connection to real mongodb servers and separates the real implementation from the mock one (previously they were in
the same file).