### PR TITLE
fix(manager): use the default '/' root path to avoid path 404 error

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -3,7 +3,6 @@
   "version": "0.5.0",
   "description": "The SPAship UI.",
   "main": "index.js",
-  "homepage": ".",
   "repository": {
     "type": "git",
     "url": "git@github.com:spaship/spaship.git",


### PR DESCRIPTION
The [CRA](https://create-react-app.dev/) is using `homepage` to setup `publicPath`.

https://create-react-app.dev/docs/deployment/#serving-the-same-build-from-different-paths

The current config will make all static files path be `./static/xxx.js/css`.
If the url is `https://xxx.com/aaa/aaa`, the static files will return 404 error.

so remove `homepage`
