### PR TITLE
refactor: rename and namespace config properties

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -39,22 +39,22 @@ When your pull request is merged, "squash and merge" should be used, and a Conve
 
 Configuration can be provided by CLI flags, environment variables, or a configuration file. Arguments are processed in that order, so CLI flags take precedence over environment variables, which take precedence over the configuration file.
 
-| Option             | Description                                                                                | CLI                | Env                      | config.json        | Default                                        |
-| ------------------ | ------------------------------------------------------------------------------------------ | ------------------ | ------------------------ | ------------------ | ---------------------------------------------- |
-| **config file**    | Where to find the config file.                                                             | `--config-file`    | `SPASHIP_API_CONFIG_FILE`| N/A                | none                                           |
-| **upload dir**     | Directory to upload SPA archives.                                                          | `--upload-dir`     | `SPASHIP_UPLOAD_DIR`     | `"upload_dir"`     | `/tmp/spaship_uploads`                         |
-| **webroot**        | Directory to extract/deploy SPAs.                                                          | `--webroot`        | `SPASHIP_WEBROOT`        | `"webroot"`        | `/var/www`                                     |
-| **host**           | Hostname to run on.                                                                        | `--host`           | `SPASHIP_HOST`           | `"host"`           | `localhost`                                    |
-| **port**           | Port to run on.                                                                            | `--port`           | `SPASHIP_API_PORT`       | `"port"`           | `8008`                                         |
-| **log-level**      | Granularity of log messages to print.                                                      | `--log-level`      | `SPASHIP_LOG_LEVEL`      | `"log_level"`      | `info`                                         |
-| **log-format**     | `pretty` for human-friendly logs, `json` for machine-friendly logs.                        | `--log-format`     | `SPASHIP_LOG_FORMAT`     | `"log_format"`     | `pretty`                                       |
-| **mongo_url**      | The hosts of your mongodb instance.                                                        | `--mongo-url`      | `SPASHIP_MONGO_URL`      | `"mongo_url"`      | `"localhost:27017"`                            |
-| **mongo_user**     | (Optional) The username of your mongodb instance.                                          | `--mongo-user`     | `SPASHIP_MONGO_USER`     | `"mongo_user"`     | `null`                                         |
-| **mongo_password** | (Optional) The password of your mongodb instance.                                          | `--mongo-password` | `SPASHIP_MONGO_PASSWORD` | `"mongo_password"` | `null`                                         |
-| **mongo_db**       | The mongodb database name.                                                                 | `--mongo-db`       | `SPASHIP_MONGO_DB`       | `"mongo_db"`       | `"spaship"`                                    |
-| **mock_db**        | Whether to use a mock database ([mongo-mock](https://github.com/williamkapke/mongo-mock)). | `--mock-db`        | `SPASHIP_MOCK_DB`        | `"mock_db"`        | `true`, except when `NODE_ENV == "production"` |
+| Option             | Description                                                         | CLI                   | Env                           | config.json           | Default                                        |
+| ------------------ | ------------------------------------------------------------------- | --------------------- | ----------------------------- | --------------------- | ---------------------------------------------- |
+| **config file**    | Where to find the config file.                                      | `--config-file`       | `SPASHIP_API_CONFIG_FILE`     | N/A                   | none                                           |
+| **upload dir**     | Directory to upload SPA archives.                                   | `--upload-dir`        | `SPASHIP_UPLOAD_DIR`          | `"upload_dir"`        | `/tmp/spaship_uploads`                         |
+| **webroot**        | Directory to extract/deploy SPAs.                                   | `--webroot`           | `SPASHIP_WEBROOT`             | `"webroot"`           | `/var/www`                                     |
+| **host**           | Hostname to run on.                                                 | `--host`              | `SPASHIP_HOST`                | `"host"`              | `localhost`                                    |
+| **port**           | Port to run on.                                                     | `--port`              | `SPASHIP_API_PORT`            | `"port"`              | `8008`                                         |
+| **log-level**      | Granularity of log messages to print.                               | `--log-level`         | `SPASHIP_LOG_LEVEL`           | `"log_level"`         | `info`                                         |
+| **log-format**     | `pretty` for human-friendly logs, `json` for machine-friendly logs. | `--log-format`        | `SPASHIP_LOG_FORMAT`          | `"log_format"`        | `pretty`                                       |
+| **mongo_url**      | The hosts of your mongodb instance.                                 | `--db:mongo:url`      | `SPASHIP_DB__MONGO__URL`      | `"db.mongo.url"`      | `"localhost:27017"`                            |
+| **mongo_user**     | (Optional) The username of your mongodb instance.                   | `--db:mongo:user`     | `SPASHIP_DB__MONGO__USER`     | `"db.mongo.user"`     | `null`                                         |
+| **mongo_password** | (Optional) The password of your mongodb instance.                   | `--db:mongo:password` | `SPASHIP_DB__MONGO__PASSWORD` | `"db.mongo.password"` | `null`                                         |
+| **mongo_db**       | The mongodb database name.                                          | `--db:mongo:db`       | `SPASHIP_DB__MONGO__DB`       | `"db.mongo.db"`       | `"spaship"`                                    |
+| **mock_db**        | Whether to use a mock database ([mongo-mock][mongo-mock]).          | `--db:mongo:mock`     | `SPASHIP_DB__MONGO__MOCK`     | `"db.mongo.mock"`     | `true`, except when `NODE_ENV == "production"` |
 
-**Note** about the filepath configurations, `config file`, `upload dir`, and `webroot`: they must be absolute paths when defined in an environment variable or config file. When defined in CLI options like, they can be written relative to CWD. Example: `--config-file=./config.json`
+**Note:** the filepath configurations (`config file`, `upload dir`, and `webroot`) must be absolute paths when defined in an environment variable or config file. When defined in CLI options like, they can be written relative to CWD. Example: `--config-file=../config.json`.
 
 **Note:** When `mock_db` is on, the mocked database will be persisted as a flat file named `mock-db.js` right here in the same directory as this README.
 
@@ -123,3 +123,5 @@ A few notes about the response.
 
 - `path` is not stored in the metadata directory; it's inferred from the SPA's directory in the webroot.
 - The "SPAnonymous" app has `null` values for name and ref because it was not deployed with `/deploy`, but it's included so that `/list` provides a complete report of what paths are being made available.
+
+[mongo-mock]: https://github.com/williamkapke/mongo-mock

--- a/packages/api/lib/db.js
+++ b/packages/api/lib/db.js
@@ -4,7 +4,7 @@
 
 const config = require("../config");
 
-if (config.get("mock_db")) {
+if (config.get("db:mongo:mock")) {
   module.exports = require("./db.mock-mongo.js");
 } else {
   module.exports = require("./db.real-mongo.js");

--- a/packages/api/lib/db.mock-mongo.js
+++ b/packages/api/lib/db.mock-mongo.js
@@ -8,11 +8,11 @@ MongoClient.persist = "mock-db.js"; //persist the data to disk
 
 // Connection URL
 const connectUrls = ["mongodb://"];
-if (config.get("mongo_user") && config.get("mongo_password")) {
-  connectUrls.push(`${config.get("mongo_user")}:${config.get("mongo_password")}@`);
+if (config.get("db:mongo:user") && config.get("db:mongo:password")) {
+  connectUrls.push(`${config.get("db:mongo:user")}:${config.get("db:mongo:password")}@`);
 }
-connectUrls.push(config.get("mongo_url"));
-connectUrls.push(`/${config.get("mongo_db")}`);
+connectUrls.push(config.get("db:mongo:url"));
+connectUrls.push(`/${config.get("db:mongo:db_name")}`);
 const url = connectUrls.join("");
 
 let reusableClient;

--- a/packages/api/lib/db.real-mongo.js
+++ b/packages/api/lib/db.real-mongo.js
@@ -4,11 +4,11 @@ const mongodb = require("mongodb");
 
 // Connection URL
 const connectUrls = ["mongodb://"];
-if (config.get("mongo_user") && config.get("mongo_password")) {
-  connectUrls.push(`${config.get("mongo_user")}:${config.get("mongo_password")}@`);
+if (config.get("db:mongo:user") && config.get("db:mongo:password")) {
+  connectUrls.push(`${config.get("db:mongo:user")}:${config.get("db:mongo:password")}@`);
 }
-connectUrls.push(config.get("mongo_url"));
-// connectUrls.push(`/${config.get("mongo_db")}`);
+connectUrls.push(config.get("db:mongo:url"));
+// connectUrls.push(`/${config.get("db:mongo:db")}`);
 const url = connectUrls.join("");
 
 log.info(`connecting to ${url}`);
@@ -28,7 +28,7 @@ async function connect(collectionName) {
   }
 
   // otherwise, connect
-  let db = reusableClient.db(config.get("mongo_db"));
+  let db = reusableClient.db(config.get("db:mongo:db_name"));
   return db.collection(collectionName);
 }
 


### PR DESCRIPTION
This renames some config properties to enable namespaced config objects.  Here's a before and after with examples.

**Before**

These configuration values (provided as envs):

  SPASHIP_MONGO_URL="your.mongo.db:27017"
  SPASHIP_MONGO_USER="mongo_user"
  SPASHIP_MONGO_PASSWORD="mFk7Pj3efPVNHWrr"
  SPASHIP_MONGO_DB="spaship-db"
  SPASHIP_MOCK_DB="false"

Would generate this config object:

```js
{
  mongo_url: "your.mongo.db:27017",
  mongo_user: "mongo_user",
  mongo_password: "mFk7Pj3efPVNHWrr",
  mongo_db: "spaship-db",
  mock_db: false
}
```

Which we can interact with in our code with calls like:

```js
config.get("mongo_user");
config.get("mock_db");
```

There are advantages to having a "flat" config object, but disadvantages too, such as namespacing (ex: `mongo_`) being
implicit in the property names rather than explicit in the data structure.  When I started adding Keycloak
configuration, which adds another 5-6 properties, it became even more clear that we should explicitly namespace the
config properties.

**After**

These configuration values (provided as envs):

  SPASHIP_DB__MONGO__URL="your.mongo.db:27017"
  SPASHIP_DB__MONGO__USER="mongo_user"
  SPASHIP_DB__MONGO__PASSWORD="mFk7Pj3efPVNHWrr"
  SPASHIP_DB__MONGO__DB="spaship-db"
  SPASHIP_DB__MONGO__MOCK="false"

Granted, the double underscores make these look a little funny, but they act as a "separator" it leads to a nice,
structured config object.

Would generate this config object:

```js
{
  db: {
    mongo: {
      url: "your.mongo.db:27017",
      user: "mongo_user",
      password: "mFk7Pj3efPVNHWrr",
      db_name: "spaship-db",
      mock: false
    }
  }
}
```

The `db` namespace leaves room for supporting other datastores in the future, and the `mongo` namespace gives us a
predictable object whose schema we could validate.

We can interact with this object in our code with calls like:

```js
config.get("db:mongo:user");
config.get("db:mongo:mock");
```

And even better, we can check if the user provided configuration for mongo with a simple call like:

```js
if (config.get("db::mongo")) {
```

That's a test that would have been pretty cumbersome with the old setup.


This is all powered by [nconf](https://www.npmjs.com/package/nconf).