### PR TITLE
fix(api): exclude invalid spa paths

### DIFF
--- a/packages/api/lib/metadata.js
+++ b/packages/api/lib/metadata.js
@@ -13,7 +13,8 @@ async function write(filename, extraData) {
 async function getAll() {
   try {
     const webrootFiles = await fsp.readdir(config.get("webroot"));
-    const spaDirs = flow(map(get))(webrootFiles);
+    const validFiles = webrootFiles.filter(fileName => /^(?![_\.])[a-zA-Z0-9\_\-]*$/.test(fileName));
+    const spaDirs = flow(map(get))(validFiles);
     return await Promise.all(spaDirs);
   } catch (e) {
     console.error(e);

--- a/packages/api/lib/metadata.test.js
+++ b/packages/api/lib/metadata.test.js
@@ -33,7 +33,8 @@ describe("api.metadata", () => {
           "spaship.yaml": "name: Baz\npath: /baz\nsingle: true\ndeploykey: arfgrn"
         },
         // some non-SPAs in the webroot
-        chrome: {},
+        _include: {},
+        _test1: {},
         ".htaccess": "# global htaccess file"
       }
     });
@@ -74,13 +75,6 @@ describe("api.metadata", () => {
           path: "/baz",
           single: true,
           deploykey: "arfgrn"
-        },
-        // some non-SPAs in the webroot
-        {
-          path: "/.htaccess"
-        },
-        {
-          path: "/chrome"
         }
       ];
 


### PR DESCRIPTION
Invalid: start with . or _. or include . in the middle
#239 
https://regexper.com/#%5E%28%3F!%5B_%5C.%5D%29%5Ba-zA-Z0-9%5C_%5C-%5D*%24
![image](https://user-images.githubusercontent.com/752130/76920364-482f4880-6906-11ea-89b9-25138e724161.png)
