### PR TITLE
fix(common): use json format as default

### DIFF
--- a/packages/common/lib/logging/pino-config.js
+++ b/packages/common/lib/logging/pino-config.js
@@ -5,19 +5,19 @@ nconf
     whitelist: ["log_level", "log_format"],
     lowerCase: true,
     parseValues: true,
-    transform: obj => {
+    transform: (obj) => {
       // remove the "SPASHIP_" prefix from environment variables
       obj.key = obj.key.replace(/^spaship_/, "");
       return obj;
-    }
+    },
   })
   .argv({
     parseValues: true,
-    transform: obj => {
+    transform: (obj) => {
       // use underscore as delimeter
       obj.key = obj.key.replace(/-/g, "_");
       return obj;
-    }
+    },
   });
 
 const configFile = nconf.get("config_file");
@@ -26,17 +26,17 @@ const configFile = nconf.get("config_file");
 if (configFile) {
   nconf.file({
     file: configFile,
-    transform: obj => {
+    transform: (obj) => {
       // use underscore as delimeter
       obj.key = obj.key.replace(/-/g, "_");
       return obj;
-    }
+    },
   });
 }
 
 nconf.defaults({
   log_level: "info",
-  log_format: "pretty" // 'json' or 'pretty'
+  log_format: "json", // 'json' or 'pretty'
 });
 
 module.exports = nconf;


### PR DESCRIPTION
<!--
Follow the steps to create the PR:

Subject: "feat/fix/docs(#issue_id): <PR Subject>"
Assignees: "Developers"
Projects: ""
-->

## Closes / Fixes / Resolves
There has a dependency missing error

```
Error: Missing `pino-pretty` module: `pino-pretty` must be installed separately
881     at getPrettyStream (/usr/local/share/.config/yarn/global/node_modules/pino/lib/tools.js:187:11)
882     at normalizeArgs (/usr/local/share/.config/yarn/global/node_modules/pino/lib/tools.js:347:16)
883     at pino (/usr/local/share/.config/yarn/global/node_modules/pino/pino.js:78:28)
884     at Object.<anonymous> (/usr/local/share/.config/yarn/global/node_modules/@spaship/common/lib/logging/pino.js:14:13)
```

We should keep use "json" as default, if someone need pretty format, they could install by theirself
<!-- Comman separated list of GitHub Issue ID(s) -->

## Explain the feature/fix

<!-- Provide a clear explaination of the feature/fix implemented -->

## Does this PR introduce a breaking change

<!-- Yes/No -->

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->

## Screenshot(s)

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

<!-- Add your screenshot(s) below this line -->

</details>

### Ready-for-merge Checklist

- [ ] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Does the change have appropriate unit tests?
- [ ] Did tests pass?
- [ ] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [ ] Was this feature demo'd and the design review approved?
