### PR TITLE
fix(#335): Added catch block to serviceWorker unregister method.

### DIFF
--- a/packages/manager/src/serviceWorker.ts
+++ b/packages/manager/src/serviceWorker.ts
@@ -60,7 +60,7 @@ export function register(config?: Config) {
 function registerValidSW(swUrl: string, config?: Config) {
   navigator.serviceWorker
     .register(swUrl)
-    .then(registration => {
+    .then((registration) => {
       registration.onupdatefound = () => {
         const installingWorker = registration.installing;
         if (installingWorker == null) {
@@ -96,7 +96,7 @@ function registerValidSW(swUrl: string, config?: Config) {
         };
       };
     })
-    .catch(error => {
+    .catch((error) => {
       console.error("Error during service worker registration:", error);
     });
 }
@@ -104,12 +104,12 @@ function registerValidSW(swUrl: string, config?: Config) {
 function checkValidServiceWorker(swUrl: string, config?: Config) {
   // Check if the service worker can be found. If it can't reload the page.
   fetch(swUrl)
-    .then(response => {
+    .then((response) => {
       // Ensure service worker exists, and that we really are getting a JS file.
       const contentType = response.headers.get("content-type");
       if (response.status === 404 || (contentType != null && contentType.indexOf("javascript") === -1)) {
         // No service worker found. Probably a different app. Reload the page.
-        navigator.serviceWorker.ready.then(registration => {
+        navigator.serviceWorker.ready.then((registration) => {
           registration.unregister().then(() => {
             window.location.reload();
           });
@@ -126,8 +126,12 @@ function checkValidServiceWorker(swUrl: string, config?: Config) {
 
 export function unregister() {
   if ("serviceWorker" in navigator) {
-    navigator.serviceWorker.ready.then(registration => {
-      registration.unregister();
-    });
+    navigator.serviceWorker.ready
+      .then((registration) => {
+        registration.unregister();
+      })
+      .catch((error) => {
+        console.error(error.message);
+      });
   }
 }


### PR DESCRIPTION
<!--
Follow the steps to create the PR:

Subject: "fix(#335): Added catch block to serviceWorker unregister method."
Assignees: "Developers"
Projects: ""
-->

## Closes / Fixes / Resolves
Fixes #335 

## Explain the feature/fix
As per https://github.com/facebook/create-react-app/pull/8272 this issue was caused by a missing catch block in the ServiceWorker unregister() method. Adding that fixed the issue.

## Does this PR introduce a breaking change
No

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Did tests pass?
