### PR TITLE
chore(#353): Enabled Docs and GH links for Manager Page Toolbar.

### DIFF
--- a/packages/manager/src/layout/PageToolbar.tsx
+++ b/packages/manager/src/layout/PageToolbar.tsx
@@ -8,8 +8,8 @@ import accessibleStyles from "@patternfly/react-styles/css/utilities/Accessibili
 
 const styles = StyleSheet.create({
   toolbar: {
-    color: "#000000 !important"
-  }
+    color: "#000000 !important",
+  },
 });
 
 export default () => {
@@ -42,12 +42,26 @@ export default () => {
     <Toolbar>
       <ToolbarGroup className={css(accessibleStyles.screenReader, accessibleStyles.visibleOnLg)}>
         <ToolbarItem>
-          <Button variant="link" icon={<FileAltIcon />} className={css(styles.toolbar)}>
+          <Button
+            component="a"
+            href="https://github.com/spaship/spaship/blob/master/README.md"
+            target="_blank"
+            variant="link"
+            icon={<FileAltIcon />}
+            className={css(styles.toolbar)}
+          >
             Documentation
           </Button>
         </ToolbarItem>
         <ToolbarItem>
-          <Button variant="link" icon={<GithubIcon />} className={css(styles.toolbar)}>
+          <Button
+            component="a"
+            href="https://github.com/spaship/spaship"
+            target="_blank"
+            variant="link"
+            icon={<GithubIcon />}
+            className={css(styles.toolbar)}
+          >
             GitHub
           </Button>
         </ToolbarItem>


### PR DESCRIPTION
## Closes / Fixes / Resolves
Resolves #353 

## Explain the feature/fix
Added `hrefs` to https://github.com/spaship/spaship/blob/master/README.md and https://github.com/spaship/spaship for the Documentation and Github links under the Page Toolbar.

## Does this PR introduce a breaking change
No

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Did tests pass?
