### PR TITLE
fix(#365): Added SPAship definition & Footer info to SPAship login page.

### DIFF
--- a/packages/manager/src/components/user/LoginPage.tsx
+++ b/packages/manager/src/components/user/LoginPage.tsx
@@ -58,6 +58,7 @@ const styles = StyleSheet.create({
   },
   footer: {
     fontSize: "0.6rem",
+    height: "6em",
   },
 });
 
@@ -98,22 +99,17 @@ export default () => {
           </CardBody>
         </Card>
       </PageSection>
-      <PageSection
-        className={css(styles.footer)}
-        variant={PageSectionVariants.darker}
-        style={{ height: "6em" }}
-        isFilled={false}
-      >
+      <PageSection className={css(styles.footer)} variant={PageSectionVariants.darker} isFilled={false}>
         Brought to you by the{" "}
-        <a href="https://github.com/spaship/spaship/graphs/contributors" target="_">
+        <a href="https://github.com/spaship/spaship/graphs/contributors" target="_blank" rel="noreferrer noopener">
           Wizards <OptimizeIcon />
         </a>{" "}
         of the{" "}
-        <a href="https://github.com/spaship/spaship" target="_">
+        <a href="https://github.com/spaship/spaship" target="_blank" rel="noreferrer noopener">
           SPAship
         </a>{" "}
         project. <br /> Code licensed under the{" "}
-        <a href="https://github.com/spaship/spaship/blob/master/LICENSE" target="_">
+        <a href="https://github.com/spaship/spaship/blob/master/LICENSE" target="_blank" rel="noreferrer noopener">
           MIT License
         </a>
         .

--- a/packages/manager/src/components/user/LoginPage.tsx
+++ b/packages/manager/src/components/user/LoginPage.tsx
@@ -8,8 +8,9 @@ import {
   Title,
   Page,
   PageSection,
-  PageSectionVariants
+  PageSectionVariants,
 } from "@patternfly/react-core";
+import { OptimizeIcon } from "@patternfly/react-icons";
 import { useHistory } from "react-router-dom";
 import { useKeycloak } from "@react-keycloak/web";
 import { StyleSheet, css } from "@patternfly/react-styles";
@@ -17,23 +18,47 @@ import Header from "../../layout/Header";
 import rocket from "../../static/img/rocket.svg";
 
 const styles = StyleSheet.create({
+  h5: {
+    fontSize: "1.2rem",
+    width: "300px",
+  },
+  defcard: {
+    width: "300px",
+  },
+  definition: {
+    color: "#72767b",
+    fontSize: "0.8rem",
+  },
+  yellow: {
+    color: "#fdb716",
+  },
   page: {
-    backgroundColor: "#ffffff"
+    backgroundColor: "#ffffff",
   },
   card: {
+    position: "absolute",
+    top: "0",
+    bottom: "0",
+    left: "0",
+    right: "0",
+    margin: "auto",
+    height: "124px",
     width: "300px",
-    zIndex: 99
+    zIndex: 99,
   },
   img: {
     position: "fixed",
     width: "40em",
     bottom: "-5em",
     right: "-7em",
-    zIndex: 0
+    zIndex: 0,
   },
   button: {
-    backgroundColor: "#fed402"
-  }
+    backgroundColor: "#fed402",
+  },
+  footer: {
+    fontSize: "0.6rem",
+  },
 });
 
 export default () => {
@@ -52,22 +77,47 @@ export default () => {
   return (
     <Page header={<Header />}>
       <PageSection variant={PageSectionVariants.light} isFilled>
-        <Bullseye>
-          <Card className={css(styles.card)}>
-            <CardHeader>
-              <Title headingLevel="h6" size="md">
-                Sign in with
-              </Title>
-            </CardHeader>
-            <CardBody>
-              <Button isBlock variant="primary" onClick={onClickLogin} className="spaship_btn">
-                Red Hat SSO
-              </Button>
-            </CardBody>
-          </Card>
-        </Bullseye>
+        <div className={css(styles.defcard)}>
+          <h5 className={css(styles.h5)}>
+            develop fast · <span className={css(styles.yellow)}>deploy faster</span>
+          </h5>
+          <div className={css(styles.definition)}>
+            SPAship is a open source platform for deploying, integrating, and managing single-page apps (SPAs).
+          </div>
+        </div>
+        <Card className={css(styles.card)}>
+          <CardHeader>
+            <Title headingLevel="h6" size="md">
+              Sign in with
+            </Title>
+          </CardHeader>
+          <CardBody>
+            <Button isBlock variant="primary" onClick={onClickLogin} className="spaship_btn">
+              Red Hat SSO
+            </Button>
+          </CardBody>
+        </Card>
       </PageSection>
-      <PageSection variant={PageSectionVariants.darker} style={{ height: "5em" }} isFilled={false}></PageSection>
+      <PageSection
+        className={css(styles.footer)}
+        variant={PageSectionVariants.darker}
+        style={{ height: "6em" }}
+        isFilled={false}
+      >
+        Brought to you by the{" "}
+        <a href="https://github.com/spaship/spaship/graphs/contributors" target="_">
+          Wizards <OptimizeIcon />
+        </a>{" "}
+        of the{" "}
+        <a href="https://github.com/spaship/spaship" target="_">
+          SPAship
+        </a>{" "}
+        project. <br /> Code licensed under the{" "}
+        <a href="https://github.com/spaship/spaship/blob/master/LICENSE" target="_">
+          MIT License
+        </a>
+        .
+      </PageSection>
       <img src={rocket} className={css(styles.img)} alt="Rocket" />
     </Page>
   );


### PR DESCRIPTION
## Closes / Fixes / Resolves
Resolves #365 

## Explain the feature/fix
Added SPAship definition and Footer info to the `/login` page.

## Does this PR introduce a breaking change
No

## Screenshot(s)
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/1418735/79763692-0567f280-8342-11ea-8eb7-bbb65b2aef16.png">

### Ready-for-merge Checklist
- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Did tests pass?
