### PR TITLE
fix(#439): Fixed API Key deletion behaviour.

### DIFF
--- a/packages/manager/src/components/authentication/APIKeyList.tsx
+++ b/packages/manager/src/components/authentication/APIKeyList.tsx
@@ -26,8 +26,20 @@ export default () => {
     setAPIKeys([...apiKeys, newAPIKeys]);
   };
 
-  const afterDelete = (oldLabel: string) => {
-    setAPIKeys(apiKeys.filter((item) => item.label !== oldLabel));
+  /**
+   * After an API Key for an environment is deleted update the API Keys list by deleting the environment entry
+   * from the old key by comparing the Label and Environment. In case there is only one environment within the
+   * API Key item, remove the entire item.
+   **/
+
+  const afterDelete = (oldEnvironment: string, oldLabel: string) => {
+    const updatedAPIKeys = apiKeys.filter((item) => {
+      if (item.label === oldLabel) {
+        item.environments = item.environments.filter((env) => env.name !== oldEnvironment);
+        return item.environments.length ? item : false;
+      } else return item;
+    });
+    setAPIKeys(updatedAPIKeys);
   };
 
   const titleToolbar = (

--- a/packages/manager/src/components/authentication/APIKeySubTable.tsx
+++ b/packages/manager/src/components/authentication/APIKeySubTable.tsx
@@ -9,7 +9,7 @@ import config from "../../config";
 interface IProps {
   label: string;
   apiKeyEnvironments: IAPIKeyEnvironment[];
-  afterDelete?: (label: string) => void;
+  afterDelete?: (environment: string, label: string) => void;
 }
 
 export default (props: IProps) => {
@@ -20,7 +20,7 @@ export default (props: IProps) => {
     const environment = config.environments.find((env) => env.name === apiKeyEnvironment.name);
     if (environment) {
       await deleteAPIKey(environment, label);
-      props.afterDelete && props.afterDelete(label);
+      props.afterDelete && props.afterDelete(environment.name, label);
     }
   };
 
@@ -38,7 +38,7 @@ export default (props: IProps) => {
             variant={ButtonVariant.danger}
             onConfirm={() => onClickConfirm(label, apiKeyEnv)}
           >
-            Are you sure delete this api key ?
+            Are you sure you want to delete this API Key?
           </ConfirmButton>
         ),
       },

--- a/packages/manager/src/components/authentication/APIKeyTable.tsx
+++ b/packages/manager/src/components/authentication/APIKeyTable.tsx
@@ -9,7 +9,7 @@ import EmptyNotFound from "../general/EmptyNotFound";
 interface IProps {
   isLoading: boolean;
   apiKeys: IAPIKey[];
-  afterDelete: (label: string) => void;
+  afterDelete: (environment: string, label: string) => void;
 }
 
 export default (props: IProps) => {


### PR DESCRIPTION
## Closes / Fixes / Resolves
Fixes #439 

## Explain the feature/fix
Updated the `afterDelete` method to update the API Keys list by deleting the environment entry from the old key by comparing the Label and Environment. In case there is only one environment within the API Key item, remove the entire item

## Does this PR introduce a breaking change
No

### Ready-for-merge Checklist
- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Did tests pass?