### PR TITLE
docs(#446): Added Keycloak Public Key usage to API Hacking documentation.

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -16,6 +16,12 @@ git@github.com:spaship/api.git
 npm install
 ```
 
+Add Keycloak Public Key ( ZSH || BASH ):
+
+```sh
+echo 'export SPASHIP_AUTH__KEYCLOAK__PUBKEY=<Keycloak Public Key>' >> ~/<.zshenv || .bashprofile>
+```
+
 From here, you can `npm start` to launch the service, or `npm run dev` to launch the service with auto-restart when source files are changed.
 
 ## Testing


### PR DESCRIPTION
## Closes / Fixes / Resolves
Resolves #446

## Explain the feature/fix
Added Keycloak Public Key usage to the `Hacking` section of the `API` package's README.

## Does this PR introduce a breaking change
No

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation: README.md