### PR TITLE
refactor: apply proper type to SPAship's JWT

### DIFF
--- a/packages/api/controllers/apiKey.js
+++ b/packages/api/controllers/apiKey.js
@@ -1,5 +1,5 @@
 const uuidv4 = require("uuid").v4;
-const { encrypt } = require("../utils/cryptoUtil");
+const { hash } = require("../utils/cryptoUtil");
 const { getUserUUID } = require("../utils/requestUtil");
 const NotFoundError = require("../utils/errors/NotFoundError");
 const APIKey = require("../models/apiKey");
@@ -25,7 +25,7 @@ module.exports.post = async (req, res, next) => {
   const { label, expiredDate } = req.body;
   const key = uuidv4();
   const shortKey = key.substring(0, 7);
-  const hashKey = encrypt(key);
+  const hashKey = hash(key);
 
   const data = {
     label,

--- a/packages/api/services/apiKeyService.js
+++ b/packages/api/services/apiKeyService.js
@@ -1,11 +1,11 @@
 const APIKey = require("../models/apiKey");
 const APIKeyError = require("../utils/errors/APIKeyError");
-const { encrypt } = require("../utils/cryptoUtil");
+const { hash } = require("../utils/cryptoUtil");
 
 const getAPIKeysByUser = (userId) => APIKey.find({ userId });
 
 const validation = async (apiKey) => {
-  const hashKey = encrypt(apiKey);
+  const hashKey = hash(apiKey);
   const result = await APIKey.findOne({ hashKey });
 
   if (result) {

--- a/packages/api/utils/cryptoUtil.js
+++ b/packages/api/utils/cryptoUtil.js
@@ -1,5 +1,5 @@
 const crypto = require("crypto");
 
-module.exports.encrypt = (str) => {
+module.exports.hash = (str) => {
   return crypto.createHash("sha256").update(str).digest("hex");
 };

--- a/packages/manager/src/keycloak.ts
+++ b/packages/manager/src/keycloak.ts
@@ -20,6 +20,8 @@ const options = {
 
 const keycloak = Keycloak(options);
 
+(window as any).kc = keycloak;
+
 function getUserToken() {
   return keycloak.tokenParsed as ISPAshipJWT;
 }

--- a/packages/manager/src/layout/HeaderTools.tsx
+++ b/packages/manager/src/layout/HeaderTools.tsx
@@ -4,6 +4,8 @@ import { useKeycloak } from "@react-keycloak/web";
 import { GithubIcon, FileAltIcon, UserIcon } from "@patternfly/react-icons";
 import styled from "styled-components";
 
+import { ISPAshipJWT } from "../keycloak";
+
 const StyledButton = styled(Button)({
   color: "#000000 !important",
 });
@@ -20,7 +22,7 @@ export default () => {
       return (
         <PageHeaderToolsItem>
           <StyledButton variant="link" icon={<UserIcon />}>
-            {(keycloak.tokenParsed as any).name}
+            {(keycloak.tokenParsed as ISPAshipJWT).name}
           </StyledButton>
         </PageHeaderToolsItem>
       );

--- a/packages/manager/src/layout/UserStatus.tsx
+++ b/packages/manager/src/layout/UserStatus.tsx
@@ -14,6 +14,7 @@ import {
 import { useHistory } from "react-router-dom";
 import UserAvatar from "../static/img/avatar.svg";
 import { useKeycloak } from "@react-keycloak/web";
+import { ISPAshipJWT } from "../keycloak";
 
 export default () => {
   const [isExpanded, setExpanded] = useState(false);
@@ -33,7 +34,7 @@ export default () => {
     return <Text component={TextVariants.p}>Not Authenticated</Text>;
   }
 
-  const token = keycloak.tokenParsed as any;
+  const token = keycloak.tokenParsed as ISPAshipJWT;
 
   return (
     <Accordion>


### PR DESCRIPTION
Apply the appropriate type to a few JWT references that were typed as `any`.