### PR TITLE
test: disable the (empty and broken) manager tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,3 @@ cache:
     - node_modules
 after_success:
   - codecov
-env:
-  - SPASHIP_LOG_LEVEL=debug
-  - SPASHIP_LOG_FORMAT=pretty

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,6 @@ cache:
     - node_modules
 after_success:
   - codecov
+env:
+  - SPASHIP_LOG_LEVEL=debug
+  - SPASHIP_LOG_FORMAT=pretty

--- a/packages/api/controllers/application.test.js
+++ b/packages/api/controllers/application.test.js
@@ -293,7 +293,7 @@ describe("Application Controller", () => {
     expect(next).toHaveBeenCalledWith(expect.objectContaining(new DeployError()));
   });
 
-  it("should redeploy an application success", async () => {
+  it("should redeploy an application successfully", async () => {
     expect(fs.existsSync("/fake/webroot/foo")).toBe(true);
     expect(fs.existsSync("/fake/new-app")).toBe(true);
 

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -13,8 +13,7 @@
   "private": true,
   "scripts": {
     "start": "HTTPS=true PORT=2468 react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test"
+    "build": "react-scripts build"
   },
   "devDependencies": {
     "@patternfly/react-core": "4.50.2",

--- a/packages/router/__mocks__/fs.js
+++ b/packages/router/__mocks__/fs.js
@@ -1,0 +1,2 @@
+process.chdir("/");
+module.exports = require("memfs");

--- a/packages/router/config.js
+++ b/packages/router/config.js
@@ -1,4 +1,5 @@
 const nconf = require("nconf");
+const { log } = require("@spaship/common/lib/logging/pino");
 
 const whitelist = ["config_file", "port", "webroot", "target", "fallback"];
 

--- a/packages/router/index.js
+++ b/packages/router/index.js
@@ -162,8 +162,10 @@ function stop() {
   clearInterval(intervalId);
   log.debug(`stopping router`);
   return new Promise((resolve) => {
-    server.close(resolve);
-    log.debug(`stopped router`);
+    server.close(() => {
+      log.debug(`stopped router`);
+      resolve();
+    });
   });
 }
 

--- a/packages/router/index.js
+++ b/packages/router/index.js
@@ -8,6 +8,8 @@ const { difference } = require("lodash");
 
 let topLevelDirsCache = [];
 
+log.debug(config.get(), "router configuration");
+
 async function updateDirCache() {
   // Load directory names into memory
   const freshDirs = await fsp.readdir(config.get("webroot"));
@@ -139,8 +141,11 @@ let intervalId;
 let server;
 
 async function start() {
+  log.debug(`starting router`);
+
   // Load the flat directory names into memory and keep them refreshed
   await updateDirCache();
+  log.debug(`router dir cache updated`);
   intervalId = setInterval(updateDirCache, 2000);
 
   // Start proxy server on port
@@ -155,8 +160,10 @@ async function start() {
  */
 function stop() {
   clearInterval(intervalId);
+  log.debug(`stopping router`);
   return new Promise((resolve) => {
     server.close(resolve);
+    log.debug(`stopped router`);
   });
 }
 

--- a/packages/router/index.test.js
+++ b/packages/router/index.test.js
@@ -1,65 +1,42 @@
 const axios = require("axios");
-const mockfs = require("mock-fs");
 const pathProxy = require("./index");
+const fs = require("fs");
+const vol = require("memfs").vol;
+
+jest.mock("fs");
 
 describe("router", () => {
   beforeEach(() => {
-    // Configured using environment variables in ./jest.config.js
-    mockfs({
-      "/var/www/spaship": {
-        foo: {
-          "spaship.yaml": "name: Foo\npath: /foo\nref: v1.0.1\nsingle: true\ndeploykey: sehvgqrnyre",
-          "index.html": "I AM FOO",
-        },
-        ROOTSPA: {
-          "spaship.yaml": "name: Root Spa\npath: /\nref: v1.0.1\nsingle: true\ndeploykey: dc34ldv3sd",
-          "index.html": "I AM ROOTSPA",
-        },
-      },
+    vol.reset();
+    vol.fromJSON({
+      "/var/www/spaship/foo/spaship.yaml": "name: Foo\npath: /foo\nref: v1.0.1\nsingle: true\ndeploykey: sehvgqrnyre",
+      "/var/www/spaship/foo/index.html": "I AM FOO",
+      "/var/www/spaship/ROOTSPA/spaship.yaml":
+        "name: Root Spa\npath: /\nref: v1.0.1\nsingle: true\ndeploykey: dc34ldv3sd",
+      "/var/www/spaship/ROOTSPA/index.html": "I AM ROOTSPA",
     });
   });
-  afterEach(() => {
-    mockfs.restore();
-  });
-  test("should respond to requests", async () => {
-    await pathProxy.start();
-    let response;
-    try {
-      response = await axios.get("http://localhost:8081/foo/");
-    } catch (e) {
-      // errors are fine; this test is only looking for a response
-      response = e.response;
-    }
-    expect(response.status).toBeGreaterThan(1);
-    expect(response.status).toBeLessThan(599);
-    await pathProxy.stop();
-  });
 
-  test("should respond to requests with duplicate slash", async () => {
-    await pathProxy.start();
-    let response;
-    try {
-      response = await axios.get("http://localhost:8081//foo/");
-    } catch (e) {
-      // errors are fine; this test is only looking for a response
-      response = e.response;
-    }
-    expect(response.status).toBeGreaterThan(1);
-    expect(response.status).toBeLessThan(599);
-    await pathProxy.stop();
-  });
-
-  test("should respond to root path spa request", async () => {
-    await pathProxy.start();
-    let response;
-    try {
-      response = await axios.get("http://localhost:8081/");
-    } catch (e) {
-      // errors are fine; this test is only looking for a response
-      response = e.response;
-    }
-    expect(response.status).toBeGreaterThan(1);
-    expect(response.status).toBeLessThan(599);
-    await pathProxy.stop();
+  // Testing basic HTTP responses for these URL and message combos.  Doesn't test for any particular response, just that
+  // it responds.  Should add a bunch of these.
+  [
+    { msg: "should respond to requests", url: "http://localhost:8084/foo/" },
+    { msg: "should respond to requests with duplicate slash", url: "http://localhost:8084//foo/" },
+    { msg: "should respond to root path spa request", url: "http://localhost:8084/" },
+  ].forEach((target) => {
+    test(target.msg, async () => {
+      await pathProxy.start();
+      let response;
+      try {
+        response = await axios.get(target.url);
+      } catch (e) {
+        // console.log(e);
+        // errors are fine; this test is only looking for a response
+        response = e.response;
+      }
+      expect(response.status).toBeGreaterThan(1);
+      expect(response.status).toBeLessThan(599);
+      await pathProxy.stop();
+    });
   });
 });

--- a/packages/router/jest.config.js
+++ b/packages/router/jest.config.js
@@ -6,4 +6,5 @@ process.env.SPASHIP_LOG_LEVEL = "debug";
 module.exports = {
   projects: ["<rootDir>"],
   collectCoverage: true,
+  testEnvironment: "node",
 };

--- a/packages/router/jest.config.js
+++ b/packages/router/jest.config.js
@@ -1,5 +1,5 @@
 process.env.SPASHIP_WEBROOT = "/var/www/spaship";
-process.env.SPASHIP_ROUTER_PORT = "8081";
+process.env.SPASHIP_ROUTER_PORT = "8084";
 process.env.SPASHIP_TARGET = "http://localhost:3333";
 process.env.SPASHIP_LOG_LEVEL = "debug";
 

--- a/packages/router/package-lock.json
+++ b/packages/router/package-lock.json
@@ -263,6 +263,12 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "fs-monkey": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.1.tgz",
+      "integrity": "sha512-fcSa+wyTqZa46iWweI7/ZiUfegOZl0SG8+dltIwFXo7+zYU9J9kpS3NB6pZcSlJdhvIwp81Adx2XhZorncxiaA==",
+      "dev": true
+    },
     "http-errors": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
@@ -368,6 +374,15 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "memfs": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.2.0.tgz",
+      "integrity": "sha512-f/xxz2TpdKv6uDn6GtHee8ivFyxwxmPuXatBb1FBwxYNuVpbM3k/Y1Z+vC0mH/dIXXrukYfe3qe5J32Dfjg93A==",
+      "dev": true,
+      "requires": {
+        "fs-monkey": "1.0.1"
+      }
     },
     "merge-descriptors": {
       "version": "1.0.1",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -35,6 +35,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "axios": "0.20.0"
+    "axios": "0.20.0",
+    "memfs": "^3.2.0"
   }
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -4,7 +4,7 @@
   "description": "SPAship path proxy. Proxies paths to the right SPA location or pass to different origin.",
   "main": "index.js",
   "scripts": {
-    "test": "../../node_modules/.bin/jest --restoreMocks --passWithNoTests",
+    "test": "SPASHIP_LOG_LEVEL=debug SPASHIP_LOG_FORMAT=pretty ../../node_modules/.bin/jest --restoreMocks --passWithNoTests",
     "start": "node $NODE_DEBUG_OPTION index.js"
   },
   "repository": {


### PR DESCRIPTION
<!--
Follow the steps to create the PR:

Subject: "feat/fix/docs(#issue_id): <PR Subject>"
Assignees: "Developers"
Projects: ""
-->

## Closes / Fixes / Resolves

Fixes broken tests.

## Explain the feature/fix

Manager has an empty test suite (it runs, but there aren't any tests) and it has begun failing.  This PR disables the
broken, empty tests to allow the rest of the tests to pass.

## Does this PR introduce a breaking change

No

# Do not modify or remove the line above.
# Everything below it will be ignored.

Requesting a pull to spaship:master from spaship:disable-manager-tests

Write a message for this pull request. The first block
of text is the title and the rest is the description.