### PR TITLE
chore: remove "Did the tests pass?" from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,6 +35,5 @@ Projects: ""
 
 - [ ] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
 - [ ] Does the change have appropriate unit tests?
-- [ ] Did tests pass?
 - [ ] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
 - [ ] Was this feature demo'd and the design review approved?


### PR DESCRIPTION
There's no need to have this.  Tests passing are enforced by github before a PR can be merged.
