### PR TITLE
fix: resolve noFallthroughCasesInSwitch typescript error

### DIFF
--- a/packages/manager/tsconfig.json
+++ b/packages/manager/tsconfig.json
@@ -11,6 +11,7 @@
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
+    "noFallthroughCasesInSwitch": true,
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react"


### PR DESCRIPTION
<!--
Follow the steps to create the PR:

Subject: "feat/fix/docs(#issue_id): <PR Subject>"
Assignees: "Developers"
Projects: ""
-->

## Closes / Fixes / Resolves

fixes #867

## Explain the feature/fix

Resolves the Manager build error:

```
TypeError: Cannot add property noFallthroughCasesInSwitch, object is not extensible
```

It seems that CRA (or maybe typescript itself?) wants to add the noFallthroughCasesInSwitch property to tsconfig.json
automatically, but it fails.  To workaround that, I added it manually.

## Does this PR introduce a breaking change

No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?