### PR TITLE
chore: regenerate cli README

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -25,7 +25,7 @@ $ npm install -g @spaship/cli
 $ spaship COMMAND
 running command...
 $ spaship (-v|--version|version)
-@spaship/cli/0.11.0 darwin-x64 node-v13.7.0
+@spaship/cli/0.11.1 linux-x64 node-v12.18.3
 $ spaship --help [COMMAND]
 USAGE
   $ spaship COMMAND
@@ -38,7 +38,39 @@ USAGE
 
 <!-- commands -->
 
+- [`spaship deploy [ARCHIVE]`](#spaship-deploy-archive)
 - [`spaship help [COMMAND]`](#spaship-help-command)
+- [`spaship init`](#spaship-init)
+
+## `spaship deploy [ARCHIVE]`
+
+deploy to a SPAship host
+
+```
+USAGE
+  $ spaship deploy [ARCHIVE]
+
+ARGUMENTS
+  ARCHIVE  SPA archive file. You can omit this if you specify the build artifact path as `buildDir` in the spaship.yaml
+           file.
+
+OPTIONS
+  -e, --env=env    [default: default] either the name of a SPAship environment as defined in your .spashiprc.yml file,
+                   or a URL to a SPAship environment
+
+  -r, --ref=ref    [default: undefined] a version tag, commit hash, or branch to identify this release
+
+  --apikey=apikey  a SPAship API key
+
+DESCRIPTION
+  Send an archive containing a SPA to a SPAship host for deployment.  Supports .tar.gz/.tgz, .zip, and .tar.bz2.
+
+EXAMPLES
+  $ npm pack && spaship deploy your-app-1.0.0.tgz # deploying an archive created with npm pack
+  $ spaship deploy # deploying a buildDir directory
+```
+
+_See code: [src/commands/deploy.js](https://github.com/spaship/spaship/blob/v0.11.1/src/commands/deploy.js)_
 
 ## `spaship help [COMMAND]`
 
@@ -56,6 +88,27 @@ OPTIONS
 ```
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v3.0.0/src/commands/help.ts)_
+
+## `spaship init`
+
+Initialize a SPAship config file for your app.
+
+```
+USAGE
+  $ spaship init
+
+OPTIONS
+  -n, --name=name    (required) a human-friendly title for your app
+  -p, --path=path    (required) the URL path for your app under the SPAship domain. ex: /my/app
+  -s, --[no-]single  route all non-asset requests to index.html
+  --overwrite        overwrite existing spaship.yaml
+
+DESCRIPTION
+  Without arguments, init will ask you a few questions and generate a spaship.yaml config file.  The answers can also be
+  passed in as CLI options.
+```
+
+_See code: [src/commands/init.js](https://github.com/spaship/spaship/blob/v0.11.1/src/commands/init.js)_
 
 <!-- commandsstop -->
 


### PR DESCRIPTION
<!--
Follow the steps to create the PR:

Subject: "feat/fix/docs(#issue_id): <PR Subject>"
Assignees: "Developers"
Projects: ""
-->

## Explain the feature/fix

It looks like the CLI's README has some problem last time it was regenerated (this happens during both the
`preversion` and `prepack` scripts), leading to
none of the CLI commands being described in the README.  I re-ran the `oclif-dev readme` command to restore the info.

## Does this PR introduce a breaking change

No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?