### PR TITLE
docs: explain what an archive file is in the SPAship CLI help

### DIFF
--- a/packages/cli/src/commands/deploy.js
+++ b/packages/cli/src/commands/deploy.js
@@ -156,7 +156,7 @@ DeployCommand.args = [
     required: false,
     default: null,
     description:
-      "SPA archive file. You can omit this if you specify the build artifact path as `buildDir` in the spaship.yaml file.",
+      "An archive (zip, tarball, or bzip2) file containing SPA static assets and a spaship.yaml file. You can omit this if you specify the build artifact path as `buildDir` in the spaship.yaml file.",
   },
 ];
 


### PR DESCRIPTION
## Explain the feature/fix

Explains what a "SPA archive file" is, when you run `spaship help deploy`.