### PR TITLE
fix: make the .env file optional for npm start

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -18,7 +18,7 @@
     "spaship-api": "./index.js"
   },
   "scripts": {
-    "start": "source ../../.env; node index.js",
+    "start": "[ -f ../../.env ] && source ../../.env; node index.js",
     "dev": "nodemon index.js",
     "test": "../../node_modules/.bin/jest --restoreMocks",
     "get-pubkey": "node scripts/fetchpk.js"

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "start": "source ../../.env; HTTPS=true PORT=$SPASHIP_MANAGER_PORT HOST=$SPASHIP_MANAGER_HOST react-scripts start",
+    "start": "[ -f ../../.env ] && source ../../.env; HTTPS=true PORT=$SPASHIP_MANAGER_PORT HOST=$SPASHIP_MANAGER_HOST react-scripts start",
     "build": "react-scripts build"
   },
   "devDependencies": {

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "SPASHIP_LOG_LEVEL=debug SPASHIP_LOG_FORMAT=pretty ../../node_modules/.bin/jest --restoreMocks --passWithNoTests",
-    "start": "source ../../.env; node $NODE_DEBUG_OPTION index.js"
+    "start": "[ -f ../../.env ] && source ../../.env; node $NODE_DEBUG_OPTION index.js"
   },
   "repository": {
     "type": "git",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -18,7 +18,7 @@
     "spaship-sync": "./index.js"
   },
   "scripts": {
-    "start": "source ../../.env; node index.js",
+    "start": "[ -f ../../.env ] && source ../../.env; node index.js",
     "dev": "nodemon index.js",
     "test": "../../node_modules/.bin/jest --restoreMocks"
   },

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
 
-source .env
+if [[ -f ".env" ]]; then
+  source .env
+fi
+
 npm run lerna run start


### PR DESCRIPTION
## Explain the feature/fix

Currently, the `npm start` scripts at the monorepo root, and in the api, manager, sync, and router, all require a `.env`
file be present at the root of the repo.  This is unintentional and this PR makes the `.env` file optional.

## Does this PR introduce a breaking change

No.

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [ ] Was this feature demo'd and the design review approved?