### PR TITLE
fix: repair regression causing API key auth to be unusable

### DIFF
--- a/packages/api/middlewares/authentication.js
+++ b/packages/api/middlewares/authentication.js
@@ -19,6 +19,7 @@ module.exports = () => {
           const propName = config.get("auth:keycloak:id_prop");
           req.user = {
             [propName]: validKey.get("userId"),
+            authType: "apikey",
           };
           return next();
         }

--- a/packages/api/middlewares/checkAccess.js
+++ b/packages/api/middlewares/checkAccess.js
@@ -1,4 +1,5 @@
 const config = require("../config");
+const get = require("lodash/get");
 
 module.exports = () => {
   return async (req, res, next) => {
@@ -15,10 +16,10 @@ module.exports = () => {
       if (userGroup) {
         roles.user = userGroup;
       }
-      const hasAdminAccess = req.user.role.indexOf(roles.admin) >= 0;
-      const hasUserAccess = req.user.role.indexOf(roles.user) >= 0;
-      console.log({ roles: req.user.role, hasAdminAccess, hasUserAccess });
-      if (hasAdminAccess || hasUserAccess) {
+      const usedApiKey = req.user.authType === "apikey" ? true : false;
+      const hasAdminAccess = req.user.role && req.user.role.indexOf(roles.admin) >= 0;
+      const hasUserAccess = req.user.role && req.user.role.indexOf(roles.user) >= 0;
+      if (usedApiKey || hasAdminAccess || hasUserAccess) {
         return next();
       } else {
         res


### PR DESCRIPTION
## Explain the feature/fix

It seems that #858 caused a regression that made API key auth unusable, because it couldn't pass the "user belongs to
required group" check.  I didn't catch it while reviewing that PR, but discovered it when working on the CLI later.
Here's a fix.  If an API key exists, we know it was created by a user who belonged to the required group.

## Does this PR introduce a breaking change

No.

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?