### PR TITLE
fix(api): accept buildDir in spaship.yaml

### DIFF
--- a/packages/common/lib/config/validate.js
+++ b/packages/common/lib/config/validate.js
@@ -28,6 +28,10 @@ const schema = {
       description: "the git ref (tag, branch, commit hash) tied to this deployment",
       type: "string",
     },
+    buildDir: {
+      description: "a directory to package and deploy (can be used instead of uploading a zip file)",
+      type: "string",
+    },
   },
   required: ["path", "name"],
 };


### PR DESCRIPTION
## Explain the feature/fix

#455 added support for a `buildDir` property in spaship.yaml.  Today, I discovered that the spaship.yaml schema which
is used to check for valid spaship.yaml files, wasn't updated.  This PR adds support for `buildDir` so the API will stop
throwing errors about invalid spaship.yaml.

One remaining question is "how was this not caught?"  I have no idea!  I just know that when I try to deploy using the
latest CLI and API, the API returns an error about invalid spaship.yaml file because it contained an unknown property:
`buildDir`.  This PR fixes that issue.

## Does this PR introduce a breaking change

No

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?