### PR TITLE
fix(cli): allow using buildDir for @org pkgs

### DIFF
--- a/packages/cli/src/common/zip.js
+++ b/packages/cli/src/common/zip.js
@@ -27,7 +27,9 @@ function zipDirectory(directoryPath, rawSpashipYml) {
     pkgData && pkgData.packageJson && pkgData.packageJson["name"] ? pkgData.packageJson["name"] : "SPAShipArchive";
   const pkgVersion =
     pkgData && pkgData.packageJson && pkgData.packageJson["version"] ? pkgData.packageJson["version"] : "";
-  const zipPath = path.join(tempDir, `${pkgName}${pkgVersion ? "-" + pkgVersion : ""}.zip`);
+  // create an absolute path to the zip file.  replace any '/' with '_' in the pkgName (forward slashes are used in
+  // organization-scoped npm package names, such as: @spaship/cli
+  const zipPath = path.join(tempDir, `${pkgName.replace(/\//g, "_")}${pkgVersion ? "-" + pkgVersion : ""}.zip`);
   return zipUtil(directoryPath, zipPath);
 }
 


### PR DESCRIPTION
## Explain the feature/fix

I was attempting to deploy a SPA whose package name (package.json `"name"`) was inside an npm org such as
`"@orgname/packagename"`.  It failed because the `/` was interpreted as a directory separator, and the buildDir code
attempted to write the zip file into the nonexistant directory.  This PR fixes the issue by simply replacing `/` with
`_` in package names.


## Does this PR introduce a breaking change

No


### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?