### PR TITLE
fix(auth): restore JWT authentication

### DIFF
--- a/packages/api/middlewares/authentication.js
+++ b/packages/api/middlewares/authentication.js
@@ -10,7 +10,8 @@ module.exports = () => {
   return async (req, res, next) => {
     const apiKey = APIKeyService.getAPIKeyFromRequest(req);
 
-    // Use API key check, it should not use apiKey to do validation
+    // If an API key was provided, try to validate it.  Except on the /apiKeys endpoint.  API keys cannot be used to
+    // create more API keys.
     if (apiKey && req.url.match(/^(?!\/v\d\/apiKeys)/)) {
       log.info("Use API Key validation");
       try {

--- a/packages/api/services/apiKeyService.js
+++ b/packages/api/services/apiKeyService.js
@@ -4,6 +4,8 @@ const { hash } = require("../utils/cryptoUtil");
 
 const getAPIKeysByUser = (userId) => APIKey.find({ userId });
 
+const apiKeyTokenRegex = /^apikey\s/i;
+
 const validation = async (apiKey) => {
   const hashKey = hash(apiKey);
   const result = await APIKey.findOne({ hashKey });
@@ -21,9 +23,15 @@ const validation = async (apiKey) => {
 // https://learning.postman.com/docs/postman/sending-api-requests/authorization/#api-key
 const getAPIKeyFromRequest = (req) => {
   const header = req.headers["authorization"];
-  const headerKey = header && header.replace(/^apikey\s/i, "");
-  const query = req.query["api_key"];
-  return query || headerKey;
+  let headerKey;
+
+  // retrieve api key from header and from querystring
+  if (header && apiKeyTokenRegex.test(header)) {
+    headerKey = header.replace(apiKeyTokenRegex, "").trim();
+  }
+  const queryKey = req.query["api_key"] && req.query["api_key"].trim();
+
+  return headerKey || queryKey;
 };
 
 module.exports = {


### PR DESCRIPTION
<!--
Follow the steps to create the PR:

Subject: "feat/fix/docs(#issue_id): <PR Subject>"
Assignees: "Developers"
Projects: ""
-->

## Closes / Fixes / Resolves

fixes #969

## Explain the feature/fix

#969 explains the problem.  This PR fixes it by changing the API key parsing function to stop treating every request
like an API key request.

It also makes a _very_ minor improvement: extra whitespace around the api key in the authorization
header is now tolerated, so `Authorization: APIKey         ABCDEFG  ` would be not fail due to the extra spaces.

## Does this PR introduce a breaking change

No.