### PR TITLE
feat(common): support (yaml, yml, YAML, YML) config files (#873)

### DIFF
--- a/packages/common/lib/config/append.test.js
+++ b/packages/common/lib/config/append.test.js
@@ -16,7 +16,8 @@ describe("common.config.append", () => {
       fileData[filename] = content;
     });
 
-    fs.promises.readFile = jest.fn(filename => fileData[filename]);
+    fs.promises.readFile = jest.fn((filename) => fileData[filename]);
+    fs.promises.access = jest.fn((filename) => true);
   });
   afterAll(() => {
     fs.promises.writeFile.mockRestore();
@@ -41,7 +42,7 @@ describe("common.config.append", () => {
     const data = { name: "Foo", path: "/foo", ref: "v1.0.0" };
 
     // make readFile throw an error to simulate a nonexistant file
-    fs.promises.readFile = jest.fn(async function() {
+    fs.promises.readFile = jest.fn(async function () {
       throw new Error();
     });
 

--- a/packages/common/lib/config/mockDataTests/common.config.read/spaship.yaml
+++ b/packages/common/lib/config/mockDataTests/common.config.read/spaship.yaml
@@ -1,0 +1,5 @@
+name: Bar
+path: /bar
+ref: v1.0.1
+single: true
+deploykey: sehvgqrnyre

--- a/packages/common/lib/config/read.js
+++ b/packages/common/lib/config/read.js
@@ -12,7 +12,7 @@ async function findAsync(arr, asyncPredicate) {
   }
 }
 
-async function read(_filepath, options = {}) {
+async function read(_filepath, options = { checkExtensionVariations: true }) {
   let filepath = _filepath;
   if (options.checkExtensionVariations) {
     const dotSplit = _filepath.split(".");

--- a/packages/common/lib/config/read.js
+++ b/packages/common/lib/config/read.js
@@ -1,10 +1,41 @@
 // Read a spaship.yaml file
-const fsp = require("fs").promises;
+const fs = require("fs");
+const fsp = fs.promises;
 const yaml = require("js-yaml");
 
-async function read(filepath) {
+async function findAsync(arr, asyncPredicate) {
+  for (const val of arr) {
+    const found = await asyncPredicate(val);
+    if (found) {
+      return val;
+    }
+  }
+}
+
+async function read(_filepath, options = {}) {
+  let filepath = _filepath;
+  if (options.checkExtensionVariations) {
+    const dotSplit = _filepath.split(".");
+    const ext = dotSplit.length >= 2 ? dotSplit.pop() : "";
+    const filePrefix = dotSplit.join(".");
+    const readableFileName = await findAsync(
+      [ext, "yml", "yaml", "YML", "YAML"].map((x) => `${filePrefix}.${x}`),
+      isReadable
+    );
+    filepath = readableFileName;
+  }
   const rawYaml = await fsp.readFile(filepath);
   return yaml.safeLoad(rawYaml, filepath);
+}
+
+async function isReadable(filepath) {
+  // Check if the file is readable.
+  try {
+    const access = await fsp.access(filepath, fs.constants.R_OK);
+    return true;
+  } catch (err) {
+    return false;
+  }
 }
 
 module.exports = read;

--- a/packages/common/lib/config/read.js
+++ b/packages/common/lib/config/read.js
@@ -22,7 +22,7 @@ async function read(_filepath, options = { checkExtensionVariations: true }) {
       [ext, "yml", "yaml", "YML", "YAML"].map((x) => `${filePrefix}.${x}`),
       isReadable
     );
-    filepath = readableFileName;
+    filepath = readableFileName || filepath;
   }
   const rawYaml = await fsp.readFile(filepath);
   return yaml.safeLoad(rawYaml, filepath);

--- a/packages/common/lib/config/read.test.js
+++ b/packages/common/lib/config/read.test.js
@@ -2,17 +2,53 @@ const fs = require("fs");
 const read = require("./read");
 
 describe("common.config.read", () => {
-  beforeAll(() => {
-    fs.promises.readFile = jest.fn();
-  });
-  afterAll(() => {
-    fs.promises.readFile.mockRestore();
-  });
   test("should read configuration data from a spaship.yaml file", async () => {
+    const fsPromisesRef = fs.promises.readFile;
+    fs.promises.readFile = jest.fn();
     const mockFileContent = "name: Foo\npath: /foo\nref: v1.0.1\nsingle: true\ndeploykey: sehvgqrnyre";
     fs.promises.readFile.mockResolvedValue(mockFileContent);
 
     const data = await read("./spaship.yaml");
     expect(data).toEqual({ name: "Foo", path: "/foo", deploykey: "sehvgqrnyre", single: true, ref: "v1.0.1" });
+    await fs.promises.readFile.mockRestore();
+    fs.promises.readFile = fsPromisesRef;
+  });
+
+  test("should read configuration data from a spaship.yaml file when input filename is spaship.yml OR spaship.YAML OR spaship.YML and checkExtensionVariations flag is true", async () => {
+    const data = await read(__dirname + "/mockDataTests/common.config.read/spaship.yml", {
+      checkExtensionVariations: true,
+    });
+    expect(data).toEqual({ name: "Bar", path: "/bar", deploykey: "sehvgqrnyre", single: true, ref: "v1.0.1" });
+
+    const data1 = await read(__dirname + "/mockDataTests/common.config.read/spaship.YAML", {
+      checkExtensionVariations: true,
+    });
+    expect(data1).toEqual({ name: "Bar", path: "/bar", deploykey: "sehvgqrnyre", single: true, ref: "v1.0.1" });
+
+    const data2 = await read(__dirname + "/mockDataTests/common.config.read/spaship.YML", {
+      checkExtensionVariations: true,
+    });
+    expect(data2).toEqual({ name: "Bar", path: "/bar", deploykey: "sehvgqrnyre", single: true, ref: "v1.0.1" });
+  });
+
+  test("should throw file doesn't exist for (spaship.yml) when checkExtensionVariations is false", async () => {
+    try {
+      await read(__dirname + "/mockDataTests/common.config.read/spaship.yml", { checkExtensionVariations: false });
+    } catch (err) {
+      expect(err.message).toMatch(/no such file or directory/);
+    }
+  });
+
+  test("should throw file doesn't exist", async () => {
+    try {
+      await read(__dirname + "/WRONG_PATH");
+    } catch (err) {
+      expect(err.message).toMatch(/no such file or directory/);
+    }
+    try {
+      await read(__dirname + "/mockDataTests/common.config.read/spaship.yml");
+    } catch (err) {
+      expect(err.message).toMatch(/no such file or directory/);
+    }
   });
 });

--- a/packages/common/lib/config/read.test.js
+++ b/packages/common/lib/config/read.test.js
@@ -1,17 +1,9 @@
-const fs = require("fs");
 const read = require("./read");
 
 describe("common.config.read", () => {
   test("should read configuration data from a spaship.yaml file", async () => {
-    const fsPromisesRef = fs.promises.readFile;
-    fs.promises.readFile = jest.fn();
-    const mockFileContent = "name: Foo\npath: /foo\nref: v1.0.1\nsingle: true\ndeploykey: sehvgqrnyre";
-    fs.promises.readFile.mockResolvedValue(mockFileContent);
-
-    const data = await read("./spaship.yaml");
-    expect(data).toEqual({ name: "Foo", path: "/foo", deploykey: "sehvgqrnyre", single: true, ref: "v1.0.1" });
-    await fs.promises.readFile.mockRestore();
-    fs.promises.readFile = fsPromisesRef;
+    const data = await read(__dirname + "/mockDataTests/common.config.read/spaship.yaml");
+    expect(data).toEqual({ name: "Bar", path: "/bar", deploykey: "sehvgqrnyre", single: true, ref: "v1.0.1" });
   });
 
   test("should read configuration data from a spaship.yaml file when input filename is spaship.yml OR spaship.YAML OR spaship.YML and checkExtensionVariations flag is true", async () => {
@@ -41,12 +33,12 @@ describe("common.config.read", () => {
 
   test("should throw file doesn't exist", async () => {
     try {
-      await read(__dirname + "/WRONG_PATH");
+      await read(__dirname + "/WRONG_PATH", { checkExtensionVariations: false });
     } catch (err) {
       expect(err.message).toMatch(/no such file or directory/);
     }
     try {
-      await read(__dirname + "/mockDataTests/common.config.read/spaship.yml");
+      await read(__dirname + "/mockDataTests/common.config.read/spaship.yml", { checkExtensionVariations: false });
     } catch (err) {
       expect(err.message).toMatch(/no such file or directory/);
     }

--- a/packages/common/lib/config/read.test.js
+++ b/packages/common/lib/config/read.test.js
@@ -32,15 +32,28 @@ describe("common.config.read", () => {
   });
 
   test("should throw file doesn't exist", async () => {
+    let err;
     try {
       await read(__dirname + "/WRONG_PATH", { checkExtensionVariations: false });
-    } catch (err) {
-      expect(err.message).toMatch(/no such file or directory/);
+    } catch (error) {
+      err = error;
     }
+    expect(err.message).toMatch(/no such file or directory/);
+
+    let err1;
     try {
       await read(__dirname + "/mockDataTests/common.config.read/spaship.yml", { checkExtensionVariations: false });
-    } catch (err) {
-      expect(err.message).toMatch(/no such file or directory/);
+    } catch (error) {
+      err1 = error;
     }
+    expect(err1.message).toMatch(/no such file or directory/);
+
+    let err2;
+    try {
+      await read(__dirname + "/WRONG_PATH", { checkExtensionVariations: true });
+    } catch (error) {
+      err2 = error;
+    }
+    expect(err2.message).toMatch(/no such file or directory/);
   });
 });


### PR DESCRIPTION
feat(common): support (yaml, yml, YAML, YML) config files (#873)

<!--
Follow the steps to create the PR:

Subject: "feat/fix/docs(#issue_id): <PR Subject>"
Assignees: "Developers"
Projects: ""
-->

## Closes / Fixes / Resolves

<!-- Comman separated list of GitHub Issue ID(s) -->
#873 
## 
- Makes common.config.read to support yaml extension variations (yaml, yml, YAML, YML) by default.
- If user wants to read exact filepath they can call `common.config.read(filepath, { checkExtensionVariation: false }`
- Adds unit tests
<!-- Provide a clear explaination of the feature/fix implemented -->

## Does this PR introduce a breaking change

No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->

## Screenshot(s)

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

<!-- Add your screenshot(s) below this line -->

</details>

### Ready-for-merge Checklist
- [ ]  Expected files: all files in this pull request are related to one feature request or issue (no stragglers)? **YES**
- [ ]  Does the change have appropriate unit tests?  **YES**
- [ ] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [ ] Was this feature demo'd and the design review approved?
