### PR TITLE
fix(#1129): replaces safe(Dump/Load) methods with the default methods.

### DIFF
--- a/packages/common/lib/config/append.test.js
+++ b/packages/common/lib/config/append.test.js
@@ -27,14 +27,14 @@ describe("common.config.append", () => {
     const filename = "spaship.yaml";
     fileData[filename] = "name: Foo\npath: /foo";
     await append(filename, { ref: "v1.0.0" });
-    const appended = yaml.safeLoad(fileData[filename]);
+    const appended = yaml.load(fileData[filename]);
     expect(appended).toEqual({ name: "Foo", path: "/foo", ref: "v1.0.0" });
   });
   test("should be able to append existing properties to update them", async () => {
     const filename = "spaship.yaml";
     fileData[filename] = "name: Foo\npath: /foo";
     await append(filename, { path: "/bar" });
-    const appended = yaml.safeLoad(fileData[filename]);
+    const appended = yaml.load(fileData[filename]);
     expect(appended).toEqual({ name: "Foo", path: "/bar" });
   });
   test("should be able to create file if a file by the given name doesn't already exist", async () => {
@@ -47,7 +47,7 @@ describe("common.config.append", () => {
     });
 
     await append(filename, data);
-    const appended = yaml.safeLoad(fileData[filename]);
+    const appended = yaml.load(fileData[filename]);
     expect(appended).toEqual(data);
 
     fs.promises.readFile.mockRestore();

--- a/packages/common/lib/config/read.js
+++ b/packages/common/lib/config/read.js
@@ -25,7 +25,7 @@ async function read(_filepath, options = { checkExtensionVariations: true }) {
     filepath = readableFileName || filepath;
   }
   const rawYaml = await fsp.readFile(filepath);
-  return yaml.safeLoad(rawYaml, filepath);
+  return yaml.load(rawYaml, filepath);
 }
 
 async function isReadable(filepath) {

--- a/packages/common/lib/config/write.js
+++ b/packages/common/lib/config/write.js
@@ -19,7 +19,7 @@ async function write(filename, data) {
     log.warn(`WARNING: configuration is invalid, `, data);
   }
 
-  const content = heading + yaml.safeDump(data);
+  const content = heading + yaml.dump(data);
   await fsp.writeFile(filename, content);
   return data;
 }


### PR DESCRIPTION
## Closes / Fixes / Resolves
Fixes #1129 

## Explain the feature/fix
replaces safe(Dump/Load) methods with the default methods within the common.read, common.write and test configurations.

## Does this PR introduce a breaking change
No

### Ready-for-merge Checklist
- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?