### PR TITLE
feat(#1145): enables `http` based API endpoint support and updates the deployment service test definitions. 

### DIFF
--- a/packages/cli/src/services/deployService.js
+++ b/packages/cli/src/services/deployService.js
@@ -1,7 +1,9 @@
 const https = require("https");
+const http = require("http");
 const pkg = require("../../package.json");
 
 const upload = (url, data, apiKey, onUploadProgress) => {
+  let protocol = url.startsWith("https://") ? https : http;
   return new Promise((resolve, reject) => {
     let contentLength = null;
     let bytes = 0;
@@ -37,7 +39,7 @@ const upload = (url, data, apiKey, onUploadProgress) => {
       headers: Object.assign({}, defaultHeaders, data.getHeaders()),
     };
 
-    const req = https.request(url, options, (res) => {
+    const req = protocol.request(url, options, (res) => {
       let rawData = "";
 
       res.on("data", (chunk) => {

--- a/packages/cli/test/services/deployService.test.js
+++ b/packages/cli/test/services/deployService.test.js
@@ -33,7 +33,7 @@ describe("deployService", () => {
       mockData.apiKey,
       () => {}
     );
-    assert.deepEqual(response, mockData.response);
+    assert.deepStrictEqual(response, mockData.response);
   });
 
   it("https: upload success", async () => {
@@ -65,7 +65,7 @@ describe("deployService", () => {
       mockData.apiKey,
       () => {}
     );
-    assert.deepEqual(response, mockData.response);
+    assert.deepStrictEqual(response, mockData.response);
   });
 
   it("https: upload failed", async () => {

--- a/packages/cli/test/services/deployService.test.js
+++ b/packages/cli/test/services/deployService.test.js
@@ -4,7 +4,39 @@ const FormData = require("form-data");
 const DeployService = require("../../src/services/deployService");
 
 describe("deployService", () => {
-  it("upload success", async () => {
+  it("http: upload success", async () => {
+    const form = new FormData();
+    form.append("name", "test-spa");
+    form.append("path", "test-spa");
+    form.append("ref", "latest");
+    const mockData = {
+      host: "http://spaship.server",
+      path: "/api/v1/application/deploy",
+      data: form,
+      apiKey: "xxxx",
+      response: {
+        status: "success",
+        data: {
+          name: "test-spa",
+          path: "/test-spa",
+          ref: "latest",
+          timestamp: "2020-05-29T01:52:53.666Z",
+        },
+      },
+    };
+
+    nock(mockData.host).post(mockData.path).reply(200, mockData.response);
+
+    const response = await DeployService.upload(
+      mockData.host + mockData.path,
+      mockData.data,
+      mockData.apiKey,
+      () => {}
+    );
+    assert.deepEqual(response, mockData.response);
+  });
+
+  it("https: upload success", async () => {
     const form = new FormData();
     form.append("name", "test-spa");
     form.append("path", "test-spa");
@@ -36,13 +68,38 @@ describe("deployService", () => {
     assert.deepEqual(response, mockData.response);
   });
 
-  it("upload failed", async () => {
+  it("https: upload failed", async () => {
     const form = new FormData();
     form.append("name", "test-spa");
     form.append("path", "test-spa");
     form.append("ref", "latest");
     const mockData = {
       host: "https://spaship.server",
+      path: "/api/v1/application/deploy",
+      data: form,
+      apiKey: "xxxx",
+      response: {
+        status: "fail",
+        message: "You are not auth",
+      },
+    };
+
+    nock(mockData.host).post(mockData.path).reply(401, mockData.response);
+
+    (async () => {
+      await assert.rejects(async () => {
+        await DeployService.upload(mockData.host + mockData.path, mockData.data, mockData.apiKey, () => {});
+      });
+    })();
+  });
+
+  it("http: upload failed", async () => {
+    const form = new FormData();
+    form.append("name", "test-spa");
+    form.append("path", "test-spa");
+    form.append("ref", "latest");
+    const mockData = {
+      host: "http://spaship.server",
       path: "/api/v1/application/deploy",
       data: form,
       apiKey: "xxxx",


### PR DESCRIPTION
## Closes / Fixes / Resolves
Fixes #1145 

## Explain the feature/fix
Enables `http` based API endpoint support and updates the deployment service test definitions. 

## Does this PR introduce a breaking change
No

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?