### PR TITLE
feat(router): Increase max http header size to 16kb.

### DIFF
--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "SPASHIP_LOG_LEVEL=debug SPASHIP_LOG_FORMAT=pretty ../../node_modules/.bin/jest --restoreMocks --passWithNoTests",
-    "start": "[ -f ../../.env ] && source ../../.env; node $NODE_DEBUG_OPTION index.js"
+    "start": "[ -f ../../.env ] && source ../../.env; node $NODE_DEBUG_OPTION --max-http-header-size=16384 index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Explain the feature/fix
Set the default value of `max-http-header-size` to 16kb
  
## Does this PR introduce a breaking change
No

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?