### PR TITLE
feat(#1325): added `--builddir` as CLI argument for deploy command

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -55,6 +55,7 @@ ARGUMENTS
            this if you specify the build artifact path as `buildDir` in the spaship.yaml file.
 
 OPTIONS
+  -b, --builddir=builddir  path of your SPAs artifact. Defaults to 'buildDir' if specified in the spaship.yaml.
   -e, --env=env    [default: default] either the name of a SPAship environment as defined in your .spashiprc.yml file,
                    or a URL to a SPAship environment
 

--- a/packages/cli/src/commands/deploy.js
+++ b/packages/cli/src/commands/deploy.js
@@ -37,7 +37,8 @@ class DeployCommand extends Command {
     // it could be store in package.json
     const name = yamlConfig ? yamlConfig.name : config.name;
     let path = flags.path || yamlPath;
-    const buildDir = yamlConfig ? yamlConfig.buildDir : config.buildDir;
+    const configBuildDir = yamlConfig ? yamlConfig.buildDir : config.buildDir; // buildDIr from config
+    const buildDir = flags.builddir ? flags.builddir : configBuildDir; // uses command line arg if present
 
     if (!name) {
       this.error("Please define your app name in your package.json or use init to create spaship.yaml ");
@@ -187,6 +188,14 @@ DeployCommand.flags = assign(
       char: "p",
       description:
         "a custom URL path for your app under the SPAship domain. Defaults to the 'path' in your spaship.yaml. ex: /my/app",
+    }),
+  },
+  {
+    builddir: flags.string({
+      char: "b",
+      required: false,
+      description:
+        "path of your SPAs artifact. Defaults to 'buildDir' if specified in the spaship.yaml.",
     }),
   },
   commonFlags.apikey,


### PR DESCRIPTION
## Closes / Fixes / Resolves
#1325

## Explain the feature/fix
- added `--builddir` as CLI argument for deploy command

## Does this PR introduce a breaking change
No

## Screenshot(s)
<details>
<summary>View Screenshots</summary>
![Screenshot 2021-09-06 at 3 43 36 PM](https://user-images.githubusercontent.com/8397274/132201462-decf61a8-c302-44f3-9dfc-3f1a75252db5.png)
</details>

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Does the change have appropriate unit tests?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [ ] Was this feature demo'd and the design review approved?
