### PR TITLE
hot-fix(spa-list-page) - Corrected names for spa path and url

### DIFF
--- a/packages/manager/components/web-property/spaProperty.tsx
+++ b/packages/manager/components/web-property/spaProperty.tsx
@@ -66,7 +66,7 @@ const SPAProperty: FunctionComponent<Properties> = ({ webprop, }: Properties) =>
             <Tr>
               <Th></Th>
               <Th>Name</Th>
-              <Th>Url</Th>
+              <Th>URL Path</Th>
               <Th>Environment(s)</Th>
             </Tr>
           </Thead>
@@ -86,7 +86,7 @@ const SPAProperty: FunctionComponent<Properties> = ({ webprop, }: Properties) =>
                     {spa.name}
                   </Button>
                 </Td>
-                <Td> {spa.name} </Td>
+                <Td> {spa.name.startsWith('/') ? spa.name : `/${spa.name}`} </Td>
                 <Td>{spa.env.map((envName: string, _index: any) => <StyledLabel key={_index}>{envName}</StyledLabel>)}</Td>
               </Tr>
               <Tr key={rowIndex} isExpanded={isSPAExpanded(spa.name)}>
@@ -97,7 +97,7 @@ const SPAProperty: FunctionComponent<Properties> = ({ webprop, }: Properties) =>
                         <Tr>
                           <Th>Environment</Th>
                           <Th>Ref</Th>
-                          <Th>Url</Th>
+                          <Th>URL</Th>
                           <Th>Updated At</Th>
                         </Tr>
                       </StyledTableHeader>

--- a/packages/manager/package-lock.json
+++ b/packages/manager/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spaship/manager",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@spaship/manager",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@patternfly/react-charts": "^6.51.19",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spaship/manager",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "description": "The SPAship UI.",
   "repository": {


### PR DESCRIPTION

## Explain the feature/fix

- Corrected names for spa path and url in the SPA list page

## Does this PR introduce a breaking change

- No

## Screenshot(s)


<details>
<summary>View Screenshots</summary>

<img width="1259" alt="Screenshot 2022-05-28 at 2 33 56 AM" src="https://user-images.githubusercontent.com/12994292/170789258-3be122d5-7f11-4a84-8f91-79ce4ee348ea.png">


</details>
