### PR TITLE
feat(manager) : delete api key feature & spinner fix

### DIFF
--- a/packages/manager/components/settings/envList.tsx
+++ b/packages/manager/components/settings/envList.tsx
@@ -31,9 +31,10 @@ const StyledCard = styled(Card)`
 `;
 
 const StyledButton = styled(Button)`
-  --pf-c-button--m-tertiary--BackgroundColor: var(--spaship-global--Color--text-red, #c9190b);
-  --pf-c-button--m-tertiary--Color: #FFFFFF;
-  --pf-c-button--BorderRadius: none;
+  --pf-c-button--m-tertiary--BackgroundColor: var(--spaship-global--Color--text-#c9190b, #FFFFF);
+  --pf-c-button--m-tertiary--Color: #c9190b;
+  --pf-c-button--BorderColor: #c9190b;
+  --pf-c-button--m-tertiary--focus--BorderColor #c9190b;
   --pf-c-button--PaddingRight: 3rem;
   --pf-c-button--PaddingLeft: 3rem;
 `;
@@ -161,7 +162,7 @@ const EnvList: FunctionComponent<Properties> = ({ webprop }: Properties) => {
                   <StyledButton variant="tertiary"
                     onClick={() => selectApiKey(key.shortKey)}
                   >
-                    <TrashIcon />
+                    <TrashIcon /> Delete
                   </StyledButton> </Td>
               </Tr>
             ))}

--- a/packages/manager/components/web-property/newProperty.tsx
+++ b/packages/manager/components/web-property/newProperty.tsx
@@ -1,17 +1,17 @@
 import {
-  Alert, 
-  Button, 
-  Form, 
-  FormGroup, 
-  FormHelperText, 
-  Text, 
-  TextInput, 
+  Alert,
+  Button,
+  Form,
+  FormGroup,
+  FormHelperText,
+  Text,
+  TextInput,
   TextVariants,
-  AlertGroup, 
-  AlertActionCloseButton, 
-  AlertVariant, 
-  getUniqueId, 
-  Flex, 
+  AlertGroup,
+  AlertActionCloseButton,
+  AlertVariant,
+  getUniqueId,
+  Flex,
   FlexItem,
   Switch,
 } from '@patternfly/react-core';
@@ -152,7 +152,11 @@ const NewProperty: FunctionComponent<NewPropertyProps> = ({ webProp }: AnyProps)
       }
       const propertyRes = await post<AnyProps>(nextUrl, payload, (session as any).accessToken);
       if (!propertyRes?.response?.id) {
-        setErrorMessage(propertyRes.response)
+        setErrorMessage(propertyRes.response);
+        setAlert([
+          { title: `${propertyRes.response}`, variant: 'danger', key: getUniqueId() },
+        ] as any)
+        setButtonLoading(false);
       }
       else {
         setAlert([
@@ -266,17 +270,17 @@ const NewProperty: FunctionComponent<NewPropertyProps> = ({ webProp }: AnyProps)
                 helperTextInvalidIcon={<ExclamationCircleIcon />}
                 validated={validatedEnv as any}
               >
-              <TextInput
-                isRequired
-                type="text"
-                id="form-group-label-info"
-                name="form-group-label-info"
-                aria-describedby="form-group-label-info-helper"
-                placeholder="Default Environment Name"
-                value={env}
-                onChange={handleEnv}
-                validated={validatedEnv as any}
-              />
+                <TextInput
+                  isRequired
+                  type="text"
+                  id="form-group-label-info"
+                  name="form-group-label-info"
+                  aria-describedby="form-group-label-info-helper"
+                  placeholder="Default Environment Name"
+                  value={env}
+                  onChange={handleEnv}
+                  validated={validatedEnv as any}
+                />
               </FormGroup>
             </FlexItem>
             <FlexItem>
@@ -284,42 +288,42 @@ const NewProperty: FunctionComponent<NewPropertyProps> = ({ webProp }: AnyProps)
                 label="Environment Type"
                 fieldId="form-group-label-env-type"
                 helperText={
-                  <FormHelperText icon={<ExclamationCircleIcon/>} isHidden={false}>
+                  <FormHelperText icon={<ExclamationCircleIcon />} isHidden={false}>
                     {`Env type for your property`}
                   </FormHelperText>
                 }
                 isRequired>
-              <StyledSwitch
-                label="Production"
-                labelOff="Pre-production"
-                id="env-type"
-                aria-label="prod and pre-prod env type checkbox"
-                isChecked={envType}
-                onChange={(status) => { setEnvType(status) }}
-              />
+                <StyledSwitch
+                  label="Production"
+                  labelOff="Pre-production"
+                  id="env-type"
+                  aria-label="prod and pre-prod env type checkbox"
+                  isChecked={envType}
+                  onChange={(status) => { setEnvType(status) }}
+                />
               </FormGroup>
             </FlexItem>
           </Flex>
-          
 
-          <StyledButton 
-          variant="tertiary" 
-          onClick={ () => {
-            handleOnClick();
-            setButtonLoading(true);
-          }
-        }
-          isLoading={buttonLoading}
-          isDisabled={
-            buttonLoading 
-            ||
-            validatedEnv != validations.success 
-            || 
-            validatedIdentifier != validations.success 
-            || 
-            validatedTitle != validations.success 
-            || 
-            validatedUrl != validations.success}>
+
+          <StyledButton
+            variant="tertiary"
+            onClick={() => {
+              handleOnClick();
+              setButtonLoading(true);
+            }
+            }
+            isLoading={buttonLoading}
+            isDisabled={
+              buttonLoading
+              ||
+              validatedEnv != validations.success
+              ||
+              validatedIdentifier != validations.success
+              ||
+              validatedTitle != validations.success
+              ||
+              validatedUrl != validations.success}>
             <StyledText component={TextVariants.h4}>
               Create
             </StyledText>

--- a/packages/manager/pages/api/delete/apiKey.tsx
+++ b/packages/manager/pages/api/delete/apiKey.tsx
@@ -1,0 +1,26 @@
+import { getSession } from "next-auth/react";
+import { AnyProps } from "../../../components/models/props";
+import { del } from "../../../utils/api.utils";
+import { getDeleteApiKeyUrl } from "../../../utils/endpoint.utils";
+
+const DeleteApiKey = async (req: AnyProps, res: AnyProps) => {
+    const url = getDeleteApiKeyUrl();
+    const token = (await getSession({ req }) as any).accessToken;
+    const propertyName = getPropertyName(req);
+    const shortKey = getShortKey(req);
+    const deleteUrl = `${url}/${propertyName}/${shortKey}`
+    const response = await del<AnyProps>(deleteUrl, {}, token);
+    return res.send({ data: { response } });
+};
+
+export default DeleteApiKey;
+
+
+function getPropertyName(req: any) {
+    return req.body.propertyName;
+}
+
+function getShortKey(req: any) {
+    return req.body.shortKey;
+}
+

--- a/packages/manager/pages/properties/[propertyName]/settings/index.tsx
+++ b/packages/manager/pages/properties/[propertyName]/settings/index.tsx
@@ -51,7 +51,7 @@ export const getServerSideProps = async (context: ContextProps) => {
           {
             propertyListResponse: finalPropertyList,
             spashipNotificationTimeout: spashipNotificationTimeout,
-            apiKeyList: apiKeyList ?? [],
+            apiKeyList: getApiKeyList(apiKeyList),
             propertyName: propertyReq,
           }
         }
@@ -64,7 +64,7 @@ export const getServerSideProps = async (context: ContextProps) => {
           spaCountResponse: spaCountResponse,
           propertyListResponse: finalPropertyList,
           spashipNotificationTimeout: spashipNotificationTimeout,
-          apiKeyList: apiKeyList ?? [],
+          apiKeyList: getApiKeyList(apiKeyList),
           propertyName: propertyReq,
         }
       },
@@ -128,6 +128,13 @@ const SettingsPage: ComponentWithAuth<Properties> = ({ webprop }: Properties) =>
     </Body>
   );
 };
+
+function getApiKeyList(apiKeyList: any) {
+  if (apiKeyList.status === 404) {
+    return [];
+  }
+  return apiKeyList ?? [];
+}
 
 function getHeaderData(propertyName: string | string[]) {
   return {

--- a/packages/manager/utils/api.utils.ts
+++ b/packages/manager/utils/api.utils.ts
@@ -16,15 +16,29 @@ function handleResponse<T>(res: Response): Promise<T> {
     if (res.status === 200 || res.status === 201) {
       res
         .json()
-        .then((json) => resolve(json.data))
+        .then((json) => resolve(getJson<T>(json)))
         .catch((err) => reject(err));
-    } else {
+    }
+    else if (res.status === 404) {
+      const resposne = JSON.parse(JSON.stringify({ status: res.status }));
+      res
+        .json()
+        .then((json) => resolve(resposne))
+        .catch((err) => reject(err));
+    }
+    else {
       res
         .json()
         .then((json) => resolve(json.message))
         .catch((err) => reject(err));
     }
   });
+}
+
+function getJson<T>(json: any): T | PromiseLike<T> {
+  if (json.data)
+    return json.data;
+  else return json;
 }
 
 export async function get<T>(url: string, token?: string): Promise<T> {
@@ -85,6 +99,6 @@ export async function del<T>(url: string, data: object, token?: string) {
   if (data) {
     options.body = JSON.stringify(data);
   }
-  const res = await fetch(url, options);
-  return handleResponse<T>(res);
+  const response = await handleResponse<T>(await fetch(url, options));
+  return response;
 }

--- a/packages/manager/utils/api.utils.ts
+++ b/packages/manager/utils/api.utils.ts
@@ -75,8 +75,8 @@ export async function upload<T>(url: string, data: FormData, token: string): Pro
     headers,
     body: data,
   };
-  const res = await fetch(url, options);
-  return handleResponse<T>(res);
+  const response = await fetch(url, options);
+  return handleResponse<T>(response);
 }
 
 export async function put<T>(url: string, data: object, token?: string): Promise<T> {
@@ -86,8 +86,8 @@ export async function put<T>(url: string, data: object, token?: string): Promise
     headers,
     body: JSON.stringify(data),
   };
-  const res = await fetch(url, options);
-  return handleResponse<T>(res);
+  const response = await handleResponse<T>(await fetch(url, options));
+  return response;
 }
 
 export async function del<T>(url: string, data: object, token?: string) {

--- a/packages/manager/utils/endpoint.utils.ts
+++ b/packages/manager/utils/endpoint.utils.ts
@@ -38,10 +38,18 @@ export function getValidateUrl() {
   return `${spashipHost}/applications/validate`;
 }
 
+export function getDeleteApiKeyUrl() {
+  return `${spashipHost}/apikeys`;
+}
+
 export function getNextValidateUrl() {
   return `/api/validate`;
 }
 
 export function getNextOnboardWebpropertyUrl() {
   return `/api/webPropertyOnboard`;
+}
+
+export function getNextDeleteApiKey() {
+  return `/api/delete/apiKey`;
 }


### PR DESCRIPTION
## Closes

-  Delete apikey button added to the manager (settings page)

## Fix

- Spinner issues resolved for the error in creating webproperty
- Handled 404 error (apikey)

## Explain the feature

- Delete api key button added into manager
- Modal will popup while you click on the delete button
- Next API & Orchestrator url added into endpoint
- Delete API Key Service added 

## Explain the fix

- Error handled for "Issue while property creation"
- Alert added if property creation failed
- 404 error handled in api.util
- No API Key present issue resolved

## Screenshots

# - Delete API Key 
![Screen Shot 2022-08-18 at 12 00 56](https://user-images.githubusercontent.com/37873518/185310011-2bcb0911-c9eb-423b-bfb4-20ed222066a8.png)
![Screen Shot 2022-08-18 at 12 01 01](https://user-images.githubusercontent.com/37873518/185310058-dc32d8eb-79d4-41dc-ab60-1bcb316baa04.png)

# - Spinner issue 
![Screen Shot 2022-08-18 at 12 01 34](https://user-images.githubusercontent.com/37873518/185310149-c83c64d7-bc85-44e8-955b-9018af6c09c0.png)


## Does this PR introduce a breaking change

- No