### PR TITLE
fix(api) : webproperty creation issue resolved

### DIFF
--- a/packages/api/controllers/apiKey.js
+++ b/packages/api/controllers/apiKey.js
@@ -32,7 +32,7 @@ module.exports.propertyList = async (req, res, next) => {
       expirationDate: obj.expiredDate,
       createdAt: obj.createdAt,
     }));
-    if (apiKeys.length == 0) res.send({ message: `No apikeys avaliable for ${propertyName}` });
+    if (apiKeys.length == 0) return res.status(404).send({ message: `No apikeys avaliable for ${propertyName}` });
     res.send(apiKeys);
   } catch (error) {
     next(error);

--- a/packages/api/controllers/operatorServices/operations/saveAlias.js
+++ b/packages/api/controllers/operatorServices/operations/saveAlias.js
@@ -20,10 +20,18 @@ module.exports = async function saveAlias(req, res, next) {
     return next(new ValidationError("Propertyname & Env exists."));
   }
   let id = await getGeneratedAliasId();
+
   let aliasRequest = await createAliasRequest(id, request);
   const createdResponse = await createEvent(aliasRequest);
-  await envCreation(request)
-  res.send(createdResponse);
+  try{
+      await envCreation(request)
+  }
+  catch(e){
+    console.log(e);
+    await alias.findOneAndDelete({ id:createdResponse.id });
+    return res.status(500).send({ message: `Issue in creating webproperty` });
+  }
+  return res.send(createdResponse);
 };
 
 function checkProperties(request) {


### PR DESCRIPTION
## Fixes

- No Env Creation exception handled
- Error code added for apikey list

## Explain the feature

- If no env is created for multiple reason (db issue, no deployment connection string present, operator outage etc), then it will be handled in the api end, and throw issues in FE
- 404 error code added if no api key found

## Does this PR introduce a breaking change

- No
