### PR TITLE
fix(api) : max limit set to 10 for deployment api/min

### DIFF
--- a/packages/api/app.js
+++ b/packages/api/app.js
@@ -20,7 +20,7 @@ const app = new express();
 const rateLimit = require("express-rate-limit");
 
 const timeLimit = 60000;
-const maxRequest = 2;
+const maxRequest = 10;
 const apiRateLimiter = rateLimit({
   windowMs: timeLimit,
   max: maxRequest,

--- a/packages/api/index.js
+++ b/packages/api/index.js
@@ -8,7 +8,6 @@ const consumeSSE = require("./controllers/operatorServices/event/consumeEvent");
 if (process.env.NODE_ENV === "production") {
   log.info(config.toObject(), `Starting SPAship ${pkgJSON.version} with the following settings`);
 } else {
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
   log.info(
     config.toObject(),
     `


### PR DESCRIPTION
## Fixes

- Rate limit set to 10

## Explain the feature

- Rate limit for deployment API set to 10

## Does this PR introduce a breaking change

- No