### PR TITLE
fix(SPASHIP-993): added check for buildDir before archiving

### DIFF
--- a/packages/cli/src/commands/deploy.js
+++ b/packages/cli/src/commands/deploy.js
@@ -97,6 +97,11 @@ class DeployCommand extends Command {
       if (buildDir) {
         // No archive path specified in the commandline as argument and buildDir is specified in the spaship.yaml
         const buildDirPath = nodePath.join(process.cwd(), buildDir);
+        try {
+          fs.statSync(buildDirPath);
+        } catch {
+          this.error(`Unable to access ${buildDirPath}, please check the buildDir value.`);
+        }
         const rawSpashipYml = await common.config.readRaw("spaship.yaml");
         this.log("Creating a zip archive...");
         try {


### PR DESCRIPTION
## Closes / Fixes / Resolves
SPASHIP-993

<!-- Comman separated list of GitHub Issue ID(s) -->

## Explain the feature/fix
Currently lets say that we are developing a react application, by default react uses "/build" to generate its distribution files. Assume that the following is my spaship.yaml file

```yaml
name: my-awesome-app
path: /application
single: true
buildDir: /dist
```

The above yaml is technically wrong since it points to /dist instead of /build. When we use spaship cli to deploy our app, it will show success message regardless of the above problem.

This PR will add a check for the buildDir and causes the SPAShip CLI to exit immediately if it doesn't exists.

<!-- Provide a clear explaination of the feature/fix implemented -->

## Does this PR introduce a breaking change
No

<!-- Yes/No -->

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->

## Screenshot(s)
n/a

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Does the change have appropriate unit tests?
- [ ] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [ ] Was this feature demo'd and the design review approved?
