### PR TITLE
fix(manager): fixed calender date going out of screen

### DIFF
--- a/packages/manager/src/views/WebPropertyEnvPage/components/CreateAPIKeyForm/CreateAPIKeyForm.tsx
+++ b/packages/manager/src/views/WebPropertyEnvPage/components/CreateAPIKeyForm/CreateAPIKeyForm.tsx
@@ -108,6 +108,12 @@ export const CreateAPIKeyForm = ({ onSubmit, onClose, envs = [], token }: Props)
                     onChange(str);
                   }}
                   appendTo={() => document.body}
+                  popoverProps={
+                    {
+                      position: 'left'
+                      // TODO: This is a ts type bug in Pfe asking for body content. Will raise it in PFE
+                    } as any
+                  }
                   onChange={(str) => {
                     onChange(str);
                     onBlur();


### PR DESCRIPTION
## Fix

## Explain the feature/fix

1. fixed calender date going out of screen

## Does this PR introduce a breaking change

No

## Screenshot(s)

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

<img width="1440" alt="Screenshot 2022-09-19 at 12 31 19 PM" src="https://user-images.githubusercontent.com/31166322/190967073-500c343e-5cc7-4aa9-9e77-4046650ded40.png">

</details>

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Does the change have appropriate unit tests?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?
