### PR TITLE
fix(manager): added end range in line chart and broken image url

### DIFF
--- a/packages/manager/src/views/AddWebPropertyPage/AddWebPropertyPage.tsx
+++ b/packages/manager/src/views/AddWebPropertyPage/AddWebPropertyPage.tsx
@@ -73,7 +73,7 @@ export const AddWebPropertyPage = (): JSX.Element => {
                 fieldId="property-title"
                 validated={error ? 'error' : 'default'}
                 helperTextInvalid={error?.message}
-                helperText="Title shouldn't contain any space, special-character"
+                helperText="Title shouldn't contain any special-character"
               >
                 <TextInput
                   isRequired

--- a/packages/manager/src/views/SPAPropertyDetailPage/SPAPropertyDetailPage.tsx
+++ b/packages/manager/src/views/SPAPropertyDetailPage/SPAPropertyDetailPage.tsx
@@ -199,17 +199,21 @@ export const SPAPropertyDetailPage = (): JSX.Element => {
                         }}
                         width={700}
                       >
-                        <ChartAxis tickFormat={(y) => dayjs(y).format('DD MMM')} />
+                        <ChartAxis />
                         <ChartAxis dependentAxis showGrid tickFormat={(x) => Number(x)} />
                         <ChartGroup>
                           {lineChartLegend.map(({ name }) => (
                             <ChartLine
                               key={`key-${name}`}
-                              data={monthyDeployChart?.data?.[name].map(({ count, startDate }) => ({
-                                name,
-                                x: startDate,
-                                y: count
-                              }))}
+                              data={monthyDeployChart?.data?.[name].map(
+                                ({ count, startDate, endDate }) => ({
+                                  name,
+                                  x: `${dayjs(startDate).format('DD MMM')} - ${dayjs(
+                                    endDate
+                                  ).format('DD MMM')}`,
+                                  y: count
+                                })
+                              )}
                             />
                           ))}
                         </ChartGroup>

--- a/packages/manager/src/views/WebPropertyDetailPage/components/EmptyInfo/EmptyInfo.tsx
+++ b/packages/manager/src/views/WebPropertyDetailPage/components/EmptyInfo/EmptyInfo.tsx
@@ -78,7 +78,9 @@ export const EmptyInfo = ({ propertyName }: Props): JSX.Element => (
     </EmptyStateBody>
     <EmptyStateSecondaryActions>
       <a target="_blank" href={env.PUBLIC_SPASHIP_GUIDE} rel="noreferrer">
-        <img src="/images/logo/spaship-logo-dark-vector.svg" alt="instruction" /> Instruction Guide
+        <img src="/img/spaship-logo.svg" alt="instruction" style={{ height: '25px' }} />
+        <br />
+        Instruction Guide
       </a>
     </EmptyStateSecondaryActions>
   </EmptyState>

--- a/packages/manager/src/views/WebPropertyListPage/WebPropertyListPage.tsx
+++ b/packages/manager/src/views/WebPropertyListPage/WebPropertyListPage.tsx
@@ -66,11 +66,11 @@ export const WebPropertyListPage = (): JSX.Element => {
   }
 
   // search filter debounced
-  const filteredWebProperties = webProperties?.data?.filter(({ propertyName, createdBy }) => {
+  const filteredWebProperties = webProperties?.data?.filter(({ propertyTitle, createdBy }) => {
     if (filter === MY_PROPERTY_LABEL && createdBy !== session?.user.email) {
       return false;
     }
-    return propertyName.toLowerCase().includes(debouncedSearchTerm.toLowerCase());
+    return propertyTitle.toLowerCase().includes(debouncedSearchTerm.toLowerCase());
   });
 
   const isWebPropertiesEmpty = filteredWebProperties?.length === 0;


### PR DESCRIPTION
## Fixes 

## Explain the feature/fix

1. Fixed label in property
2. Added end range in line chart
3. Fixed search not working with space
4. Fixed broken empty info url

## Does this PR introduce a breaking change

No

## Screenshot(s)

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

## Line Chart

![Screenshot 2022-09-22 at 10 53 39 AM](https://user-images.githubusercontent.com/31166322/191674341-745f2a9e-fbac-4bbc-9123-f36d46a3df41.png)

## Broken Logo

![Screenshot 2022-09-22 at 10 49 17 AM](https://user-images.githubusercontent.com/31166322/191674322-17430fd9-b634-470a-b98b-1a9be01e3254.png)


</details>

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?
