### PR TITLE
Authentication support for the operator

### DIFF
--- a/packages/operator/pom.xml
+++ b/packages/operator/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.spaship</groupId>
   <artifactId>spa-deployment-operator</artifactId>
-  <version>2.3.0</version>
+  <version>2.4.0</version>
   <properties>
     <compiler-plugin.version>3.9.0</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/packages/operator/src/main/java/io/spaship/operator/api/EnvironmentController.java
+++ b/packages/operator/src/main/java/io/spaship/operator/api/EnvironmentController.java
@@ -6,12 +6,14 @@ import io.spaship.operator.service.k8s.Operator;
 import io.spaship.operator.service.k8s.SideCarOperations;
 import io.spaship.operator.type.Environment;
 import io.spaship.operator.type.OperationResponse;
+import io.quarkus.security.Authenticated;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import java.util.Objects;
 
 @Path("environment")
+@Authenticated
 public class EnvironmentController {
 
 

--- a/packages/operator/src/main/java/io/spaship/operator/api/EventStream.java
+++ b/packages/operator/src/main/java/io/spaship/operator/api/EventStream.java
@@ -11,7 +11,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 @Path("/event")
-@Authenticated
 public class EventStream {
 
   private final Vertx vertx;

--- a/packages/operator/src/main/java/io/spaship/operator/api/EventStream.java
+++ b/packages/operator/src/main/java/io/spaship/operator/api/EventStream.java
@@ -1,6 +1,5 @@
 package io.spaship.operator.api;
 
-import io.quarkus.security.Authenticated;
 import io.smallrye.mutiny.Multi;
 import io.vertx.mutiny.core.Vertx;
 import org.eclipse.microprofile.config.ConfigProvider;

--- a/packages/operator/src/main/java/io/spaship/operator/api/EventStream.java
+++ b/packages/operator/src/main/java/io/spaship/operator/api/EventStream.java
@@ -1,5 +1,6 @@
 package io.spaship.operator.api;
 
+import io.quarkus.security.Authenticated;
 import io.smallrye.mutiny.Multi;
 import io.vertx.mutiny.core.Vertx;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -10,6 +11,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 @Path("/event")
+@Authenticated
 public class EventStream {
 
   private final Vertx vertx;

--- a/packages/operator/src/main/java/io/spaship/operator/api/SpaDeploymentController.java
+++ b/packages/operator/src/main/java/io/spaship/operator/api/SpaDeploymentController.java
@@ -1,6 +1,7 @@
 package io.spaship.operator.api;
 
 
+import io.quarkus.security.Authenticated;
 import io.spaship.operator.business.SPAUploadHandler;
 import io.spaship.operator.exception.ValidationException;
 import io.spaship.operator.repo.SharedRepository;
@@ -19,6 +20,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 @Path("upload")
+@Authenticated
 public class SpaDeploymentController {
 
   private static final Logger LOG = LoggerFactory.getLogger(SpaDeploymentController.class);

--- a/packages/operator/src/main/resources/META-INF/resources/index.html
+++ b/packages/operator/src/main/resources/META-INF/resources/index.html
@@ -304,7 +304,7 @@
           <ul>
             <li>GroupId: <code>io.spaship</code></li>
             <li>ArtifactId: <code>spa-deployment-operator</code></li>
-            <li>Version: <code>2.3.0</code></li>
+            <li>Version: <code>2.4.0</code></li>
             <li>Quarkus Version: <code>2.9.0.Final</code></li>
           </ul>
         </div>

--- a/packages/operator/src/main/resources/application.properties
+++ b/packages/operator/src/main/resources/application.properties
@@ -15,12 +15,12 @@ quarkus.log.category."io.fabric8.kubernetes.client.informers.cache".level=WARN
 %test.quarkus.log.category."io.spaship".level=DEBUG
 quarkus.log.category."io.spaship".level=INFO
 # OIDC
-quarkus.oidc.enabled=false
-quarkus.oidc.auth-server-url=
-quarkus.oidc.client-id=
+quarkus.oidc.enabled=true
+quarkus.oidc.auth-server-url=xxxx
+quarkus.oidc.client-id=xxxxx
 quarkus.oidc.credentials.secret=
-%dev.quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/spaship
-%dev.quarkus.oidc.client-id=spaship-manager
+#%dev.quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/spaship
+#%dev.quarkus.oidc.client-id=spaship-manager
 operator.event.bus.address=spa-ops-event-channel
 operator.domain.name=
 %dev.operator.domain.name=apps.int.spoke.preprod.us-east-1.aws.paas.redhat.com


### PR DESCRIPTION
## Closes
Authentication support for the operator

## Explain the feature/fix
OIDC setup is enabled from the app configuration, and sensitive APIs are now auth protected.

## Does this PR introduce a breaking change

Yes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->

Without an OIDC access token, the orchestrator (middleware) can't access the operator's API, and doing so will result in 401 errors. 

<!-- If applicable, add screenshots to help explain your problem. -->


</details>

