### PR TITLE
feat(operator): Auto update env specific sync config when it is scheduled through the operator's sync api.

### DIFF
--- a/packages/operator/src/main/java/io/spaship/operator/api/EnvironmentController.java
+++ b/packages/operator/src/main/java/io/spaship/operator/api/EnvironmentController.java
@@ -46,7 +46,7 @@ public class EnvironmentController {
   public Uni<String> scheduleSync(@QueryParam("envName") String envName,
                                   @QueryParam("websiteName") String websiteName,
                                   @QueryParam("nameSpace") String nameSpace,
-                                  Object syncRequestBody) {
+                                  String syncRequestBody) {
 
     Environment environment = new Environment(
       envName,

--- a/packages/operator/src/main/java/io/spaship/operator/service/k8s/Operator.java
+++ b/packages/operator/src/main/java/io/spaship/operator/service/k8s/Operator.java
@@ -398,5 +398,18 @@ public class Operator implements Operations {
 
   }
 
+  public ConfigMap updateConfigMap(Environment environment, Object syncConfig){
+
+    var configMapName = "sidecar-config-"
+      .concat(environment.getWebsiteName().toLowerCase())
+      .concat("-")
+      .concat(environment.getName().toLowerCase());
+    var cfgMapData =  k8sClient.configMaps().inNamespace(environment.getNameSpace()).withName(configMapName).get();
+    var existingConfigData =  cfgMapData.getData();
+    existingConfigData.put("SIDECAR_SYNC_CONFIG",syncConfig.toString());
+    cfgMapData.setData(existingConfigData);
+    return k8sClient.configMaps().inNamespace(environment.getNameSpace()).createOrReplace(cfgMapData);
+  }
+
 
 }


### PR DESCRIPTION
<!--
Follow the steps to create the PR:

Subject: "feat/fix/docs(#issue_id): <PR Subject>"
Assignees: "Developers"
Projects: ""
-->

## Resolves
Manually triggering the sync on sidecar container restart.

## Explain the feature/fix

When scheduling sync from the sync API, the operator updates the sync config of the specific environment and adds the updated sync JSON so that on the next restart, the sidecar container automatically picks up the sync from the config and schedules the Sync.


## Does this PR introduce a breaking change

No

