### PR TITLE
fix/prop-page(manager) : Changes in web property instruction page: Env filter visible in web property depending on whether spas are deployed or not

### DIFF
--- a/packages/manager/package-lock.json
+++ b/packages/manager/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spaship/manager",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@spaship/manager",
-      "version": "2.1.9",
+      "version": "2.1.10",
       "dependencies": {
         "@formkit/auto-animate": "1.0.0-beta.5",
         "@hookform/resolvers": "2.9.10",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spaship/manager",
   "description": "The SPAship UI.",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "private": true,
   "author": {
     "name": "Akhil Mohan",

--- a/packages/manager/src/views/WebPropertyDetailPage/WebPropertyDetailPage.tsx
+++ b/packages/manager/src/views/WebPropertyDetailPage/WebPropertyDetailPage.tsx
@@ -3,11 +3,7 @@ import Link from 'next/link';
 import Router, { useRouter } from 'next/router';
 import {
   Badge,
-  Bullseye,
   Button,
-  EmptyState,
-  EmptyStateIcon,
-  EmptyStateVariant,
   Label,
   Level,
   LevelItem,
@@ -20,13 +16,12 @@ import {
   Tabs,
   TabTitleIcon,
   TabTitleText,
-  Title,
   Select,
   SelectOption,
   SelectVariant
 } from '@patternfly/react-core';
 
-import { Banner, TableRowSkeleton } from '@app/components';
+import { Banner } from '@app/components';
 import { useGetSPAPropGroupByName } from '@app/services/spaProperty';
 import { useGetWebPropertyGroupedByEnv } from '@app/services/persistent';
 import { useGetEphemeralListForProperty } from '@app/services/ephemeral';
@@ -46,7 +41,6 @@ import {
   ExternalLinkAltIcon,
   PackageIcon,
   RunningIcon,
-  SearchIcon,
   TimesCircleIcon
 } from '@patternfly/react-icons';
 import { useDebounce, useFormatDate, useTabs, useToggle } from '@app/hooks';
@@ -77,8 +71,8 @@ export const WebPropertyDetailPage = (): JSX.Element => {
   const spaPropertyKeys = Object.keys(spaProperties.data || {});
   const isSpaPropertyListEmpty = spaPropertyKeys.length === 0;
   const webPropertiesKeys = Object.keys(webProperties.data || {});
-  const isWebPropertiesListEmpty = webPropertiesKeys.length === 0;
-
+  const countOfSpas = useGetSPAPropGroupByName(propertyIdentifier, '');
+  const countOfSpasListEmpty = Object.keys(countOfSpas).length === 0;
   useEffect(() => {
     if (spaProperties.isError || webProperties.isError) {
       toast.error(`Sorry cannot find ${propertyIdentifier}`);
@@ -137,7 +131,9 @@ export const WebPropertyDetailPage = (): JSX.Element => {
             }
             aria-label="SPA listing"
           >
-            {!spaProperties.isLoading && isSpaPropertyListEmpty ? (
+            {!spaProperties.isLoading &&
+            !countOfSpasListEmpty &&
+            Object.values(countOfSpas.data || {}).flat().length === 0 ? (
               <EmptyInfo propertyIdentifier={propertyIdentifier} />
             ) : (
               <>
@@ -198,144 +194,122 @@ export const WebPropertyDetailPage = (): JSX.Element => {
                     </div>
                   )}
                 </div>
-                <TableComposable aria-label="spa-property-list" className="">
-                  <Caption>SPA&apos;s DEPLOYED</Caption>
-                  <Thead>
-                    <Tr>
-                      <Th />
-                      <Th>Name</Th>
-                      <Th>URL Path</Th>
-                      <Th>Environments</Th>
-                    </Tr>
-                  </Thead>
-
-                  {((spaProperties.isSuccess && isSpaPropertyListEmpty) ||
-                    (webProperties.isSuccess && isWebPropertiesListEmpty) ||
-                    spaProperties.isLoading ||
-                    webProperties.isLoading) && (
-                    <Tbody>
-                      {(spaProperties.isLoading || webProperties.isLoading) && (
-                        <TableRowSkeleton rows={3} columns={4} />
-                      )}
-                      {spaProperties.isSuccess && isSpaPropertyListEmpty && (
-                        <Tr>
-                          <Td colSpan={4}>
-                            <Bullseye>
-                              <EmptyState variant={EmptyStateVariant.small}>
-                                <EmptyStateIcon icon={SearchIcon} />
-                                <Title headingLevel="h2" size="lg">
-                                  No results found
-                                </Title>
-                                <Button>Clear all filters</Button>
-                              </EmptyState>
-                            </Bullseye>
-                          </Td>
-                        </Tr>
-                      )}
-                    </Tbody>
-                  )}
-                  {spaProperties.isSuccess &&
-                    webPropertiesKeys &&
-                    spaPropertyKeys
-                      .filter((el) => el.toLowerCase().includes(debouncedSearchTerm))
-                      .map((identifier, rowIndex) => (
-                        <Tbody isExpanded={Boolean(isRowExpanded?.[identifier])} key={identifier}>
-                          <Tr isStriped={Boolean(rowIndex % 2)}>
-                            <Td
-                              expand={{
-                                rowIndex,
-                                isExpanded: Boolean(isRowExpanded?.[identifier]),
-                                onToggle: () => onToggleRowExpanded(identifier),
-                                expandId: 'composable-property-table'
-                              }}
-                            />
-                            <Td>
-                              <Link
-                                href={{
-                                  pathname: '/properties/[propertyIdentifier]/[spaProperty]',
-                                  query: { propertyIdentifier, spaProperty: identifier }
+                {spaProperties.isSuccess && isSpaPropertyListEmpty ? (
+                  <EmptyInfo propertyIdentifier={propertyIdentifier} />
+                ) : (
+                  <TableComposable aria-label="spa-property-list" className="">
+                    <Caption>SPA&apos;s DEPLOYED</Caption>
+                    <Thead>
+                      <Tr>
+                        <Th />
+                        <Th>Name</Th>
+                        <Th>URL Path</Th>
+                        <Th>Environments</Th>
+                      </Tr>
+                    </Thead>
+                    {spaProperties.isSuccess &&
+                      webPropertiesKeys &&
+                      spaPropertyKeys
+                        .filter((el) => el.toLowerCase().includes(debouncedSearchTerm))
+                        .map((identifier, rowIndex) => (
+                          <Tbody isExpanded={Boolean(isRowExpanded?.[identifier])} key={identifier}>
+                            <Tr isStriped={Boolean(rowIndex % 2)}>
+                              <Td
+                                expand={{
+                                  rowIndex,
+                                  isExpanded: Boolean(isRowExpanded?.[identifier]),
+                                  onToggle: () => onToggleRowExpanded(identifier),
+                                  expandId: 'composable-property-table'
                                 }}
-                              >
-                                {spaProperties.data[identifier]?.[0]?.name}
-                              </Link>
-                            </Td>
-                            <Td>{spaProperties.data[identifier]?.[0]?.path}</Td>
-                            <Td>
-                              <Split hasGutter>
-                                {spaProperties.data[identifier].map(({ _id, env }) => (
-                                  <SplitItem key={_id}>
-                                    <Label color="gold" isCompact>
-                                      {env}
-                                    </Label>
-                                  </SplitItem>
-                                ))}
-                              </Split>
-                            </Td>
-                          </Tr>
-                          <Tr isExpanded={Boolean(isRowExpanded?.[identifier])}>
-                            <Td colSpan={4} noPadding={false}>
-                              <ExpandableRowContent>
-                                <TableComposable
-                                  variant="compact"
-                                  aria-label="expandable-table"
-                                  borders={false}
+                              />
+                              <Td>
+                                <Link
+                                  href={{
+                                    pathname: '/properties/[propertyIdentifier]/[spaProperty]',
+                                    query: { propertyIdentifier, spaProperty: identifier }
+                                  }}
                                 >
-                                  <Thead>
-                                    <Tr>
-                                      <Th>Environment Name</Th>
-                                      <Th>Ref</Th>
-                                      <Th>Publish Domain</Th>
-                                      <Th>Internal Access URL</Th>
-                                      <Th>Updated At</Th>
-                                    </Tr>
-                                  </Thead>
-                                  <Tbody>
-                                    {spaProperties?.data?.[identifier].map(
-                                      ({ _id, env, ref, accessUrl, updatedAt }) => (
-                                        <Tr key={_id}>
-                                          <Td>
-                                            <Label color="gold" isCompact>
-                                              {env}
-                                            </Label>
-                                          </Td>
-                                          <Td>{ref}</Td>
-                                          <Td>
-                                            <a
-                                              href={`https://${webProperties?.data?.[env]?.url}`}
-                                              target="_blank"
-                                              rel="noopener noreferrer"
-                                            >
-                                              <ExternalLinkAltIcon />{' '}
-                                              {webProperties?.data?.[env]?.url}
-                                            </a>
-                                          </Td>
+                                  {spaProperties.data[identifier]?.[0]?.name}
+                                </Link>
+                              </Td>
+                              <Td>{spaProperties.data[identifier]?.[0]?.path}</Td>
+                              <Td>
+                                <Split hasGutter>
+                                  {spaProperties.data[identifier].map(({ _id, env }) => (
+                                    <SplitItem key={_id}>
+                                      <Label color="gold" isCompact>
+                                        {env}
+                                      </Label>
+                                    </SplitItem>
+                                  ))}
+                                </Split>
+                              </Td>
+                            </Tr>
+                            <Tr isExpanded={Boolean(isRowExpanded?.[identifier])}>
+                              <Td colSpan={4} noPadding={false}>
+                                <ExpandableRowContent>
+                                  <TableComposable
+                                    variant="compact"
+                                    aria-label="expandable-table"
+                                    borders={false}
+                                  >
+                                    <Thead>
+                                      <Tr>
+                                        <Th>Environment Name</Th>
+                                        <Th>Ref</Th>
+                                        <Th>Publish Domain</Th>
+                                        <Th>Internal Access URL</Th>
+                                        <Th>Updated At</Th>
+                                      </Tr>
+                                    </Thead>
+                                    <Tbody>
+                                      {spaProperties?.data?.[identifier].map(
+                                        ({ _id, env, ref, accessUrl, updatedAt }) => (
+                                          <Tr key={_id}>
+                                            <Td>
+                                              <Label color="gold" isCompact>
+                                                {env}
+                                              </Label>
+                                            </Td>
+                                            <Td>{ref}</Td>
+                                            <Td>
+                                              <a
+                                                href={`https://${webProperties?.data?.[env]?.url}`}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                              >
+                                                <ExternalLinkAltIcon />{' '}
+                                                {webProperties?.data?.[env]?.url}
+                                              </a>
+                                            </Td>
 
-                                          <Td>
-                                            <a
-                                              href={accessUrl}
-                                              target="_blank"
-                                              rel="noopener noreferrer"
-                                            >
-                                              <ExternalLinkAltIcon />{' '}
-                                              {`${accessUrl.slice(0, URL_LENGTH_LIMIT)} ${
-                                                accessUrl.length > URL_LENGTH_LIMIT ? '...' : ''
-                                              }`}
-                                            </a>
-                                          </Td>
-                                          <Td>
-                                            {formatDate(updatedAt, 'MMM DD, YYYY - hh:mm:ss A')}
-                                          </Td>
-                                        </Tr>
-                                      )
-                                    )}
-                                  </Tbody>
-                                </TableComposable>
-                              </ExpandableRowContent>
-                            </Td>
-                          </Tr>
-                        </Tbody>
-                      ))}
-                </TableComposable>
+                                            <Td>
+                                              <a
+                                                href={accessUrl}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                              >
+                                                <ExternalLinkAltIcon />{' '}
+                                                {`${accessUrl.slice(0, URL_LENGTH_LIMIT)} ${
+                                                  accessUrl.length > URL_LENGTH_LIMIT ? '...' : ''
+                                                }`}
+                                              </a>
+                                            </Td>
+                                            <Td>
+                                              {formatDate(updatedAt, 'MMM DD, YYYY - hh:mm:ss A')}
+                                            </Td>
+                                          </Tr>
+                                        )
+                                      )}
+                                    </Tbody>
+                                  </TableComposable>
+                                </ExpandableRowContent>
+                              </Td>
+                            </Tr>
+                          </Tbody>
+                        ))}
+                  </TableComposable>
+                )}
               </>
             )}
           </Tab>

--- a/packages/manager/src/views/WebPropertyDetailPage/WebPropertyDetailPage.tsx
+++ b/packages/manager/src/views/WebPropertyDetailPage/WebPropertyDetailPage.tsx
@@ -22,7 +22,7 @@ import {
 } from '@patternfly/react-core';
 
 import { Banner, TableRowSkeleton } from '@app/components';
-import { useGetSPAPropGroupByName } from '@app/services/spaProperty';
+import { useGetSPAPropGroupByName, useGetSPAProperties } from '@app/services/spaProperty';
 import { useGetWebPropertyGroupedByEnv } from '@app/services/persistent';
 import { useGetEphemeralListForProperty } from '@app/services/ephemeral';
 import {
@@ -71,8 +71,8 @@ export const WebPropertyDetailPage = (): JSX.Element => {
   const spaPropertyKeys = Object.keys(spaProperties.data || {});
   const isSpaPropertyListEmpty = spaPropertyKeys.length === 0;
   const webPropertiesKeys = Object.keys(webProperties.data || {});
-  const countOfSpas = useGetSPAPropGroupByName(propertyIdentifier, '');
-  const countOfSpasListEmpty = Object.keys(countOfSpas).length === 0;
+  const countOfSpas = useGetSPAProperties(propertyIdentifier, '');
+  const isCountOfSpasListEmpty = Object.keys(countOfSpas).length === 0;
   useEffect(() => {
     if (spaProperties.isError || webProperties.isError) {
       toast.error(`Sorry cannot find ${propertyIdentifier}`);
@@ -132,8 +132,8 @@ export const WebPropertyDetailPage = (): JSX.Element => {
             aria-label="SPA listing"
           >
             {!spaProperties.isLoading &&
-            !countOfSpasListEmpty &&
-            Object.values(countOfSpas.data || {}).flat().length === 0 ? (
+            !isCountOfSpasListEmpty &&
+            Object.values(countOfSpas.data || {}).length === 0 ? (
               <EmptyInfo propertyIdentifier={propertyIdentifier} />
             ) : (
               <>

--- a/packages/manager/src/views/WebPropertyDetailPage/WebPropertyDetailPage.tsx
+++ b/packages/manager/src/views/WebPropertyDetailPage/WebPropertyDetailPage.tsx
@@ -21,7 +21,7 @@ import {
   SelectVariant
 } from '@patternfly/react-core';
 
-import { Banner } from '@app/components';
+import { Banner, TableRowSkeleton } from '@app/components';
 import { useGetSPAPropGroupByName } from '@app/services/spaProperty';
 import { useGetWebPropertyGroupedByEnv } from '@app/services/persistent';
 import { useGetEphemeralListForProperty } from '@app/services/ephemeral';
@@ -72,6 +72,7 @@ export const WebPropertyDetailPage = (): JSX.Element => {
   const isSpaPropertyListEmpty = spaPropertyKeys.length === 0;
   const webPropertiesKeys = Object.keys(webProperties.data || {});
   const countOfSpas = useGetSPAPropGroupByName(propertyIdentifier, '');
+  console.log("LLL",countOfSpas, webPropertiesKeys)
   const countOfSpasListEmpty = Object.keys(countOfSpas).length === 0;
   useEffect(() => {
     if (spaProperties.isError || webProperties.isError) {
@@ -132,8 +133,8 @@ export const WebPropertyDetailPage = (): JSX.Element => {
             aria-label="SPA listing"
           >
             {!spaProperties.isLoading &&
-            !countOfSpasListEmpty &&
-            Object.values(countOfSpas.data || {}).flat().length === 0 ? (
+              !countOfSpasListEmpty &&
+              Object.values(countOfSpas.data || {}).flat().length === 0 ? (
               <EmptyInfo propertyIdentifier={propertyIdentifier} />
             ) : (
               <>
@@ -213,99 +214,104 @@ export const WebPropertyDetailPage = (): JSX.Element => {
                         .filter((el) => el.toLowerCase().includes(debouncedSearchTerm))
                         .map((identifier, rowIndex) => (
                           <Tbody isExpanded={Boolean(isRowExpanded?.[identifier])} key={identifier}>
-                            <Tr isStriped={Boolean(rowIndex % 2)}>
-                              <Td
-                                expand={{
-                                  rowIndex,
-                                  isExpanded: Boolean(isRowExpanded?.[identifier]),
-                                  onToggle: () => onToggleRowExpanded(identifier),
-                                  expandId: 'composable-property-table'
-                                }}
-                              />
-                              <Td>
-                                <Link
-                                  href={{
-                                    pathname: '/properties/[propertyIdentifier]/[spaProperty]',
-                                    query: { propertyIdentifier, spaProperty: identifier }
+                            
+                            {(spaProperties.isLoading || webProperties.isLoading) ? (
+                              <TableRowSkeleton rows={3} columns={4} />
+                            ) : <>
+                              <Tr isStriped={Boolean(rowIndex % 2)}>
+                                <Td
+                                  expand={{
+                                    rowIndex,
+                                    isExpanded: Boolean(isRowExpanded?.[identifier]),
+                                    onToggle: () => onToggleRowExpanded(identifier),
+                                    expandId: 'composable-property-table'
                                   }}
-                                >
-                                  {spaProperties.data[identifier]?.[0]?.name}
-                                </Link>
-                              </Td>
-                              <Td>{spaProperties.data[identifier]?.[0]?.path}</Td>
-                              <Td>
-                                <Split hasGutter>
-                                  {spaProperties.data[identifier].map(({ _id, env }) => (
-                                    <SplitItem key={_id}>
-                                      <Label color="gold" isCompact>
-                                        {env}
-                                      </Label>
-                                    </SplitItem>
-                                  ))}
-                                </Split>
-                              </Td>
-                            </Tr>
-                            <Tr isExpanded={Boolean(isRowExpanded?.[identifier])}>
-                              <Td colSpan={4} noPadding={false}>
-                                <ExpandableRowContent>
-                                  <TableComposable
-                                    variant="compact"
-                                    aria-label="expandable-table"
-                                    borders={false}
+                                />
+                                <Td>
+                                  <Link
+                                    href={{
+                                      pathname: '/properties/[propertyIdentifier]/[spaProperty]',
+                                      query: { propertyIdentifier, spaProperty: identifier }
+                                    }}
                                   >
-                                    <Thead>
-                                      <Tr>
-                                        <Th>Environment Name</Th>
-                                        <Th>Ref</Th>
-                                        <Th>Publish Domain</Th>
-                                        <Th>Internal Access URL</Th>
-                                        <Th>Updated At</Th>
-                                      </Tr>
-                                    </Thead>
-                                    <Tbody>
-                                      {spaProperties?.data?.[identifier].map(
-                                        ({ _id, env, ref, accessUrl, updatedAt }) => (
-                                          <Tr key={_id}>
-                                            <Td>
-                                              <Label color="gold" isCompact>
-                                                {env}
-                                              </Label>
-                                            </Td>
-                                            <Td>{ref}</Td>
-                                            <Td>
-                                              <a
-                                                href={`https://${webProperties?.data?.[env]?.url}`}
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                              >
-                                                <ExternalLinkAltIcon />{' '}
-                                                {webProperties?.data?.[env]?.url}
-                                              </a>
-                                            </Td>
+                                    {spaProperties.data[identifier]?.[0]?.name}
+                                  </Link>
+                                </Td>
+                                <Td>{spaProperties.data[identifier]?.[0]?.path}</Td>
+                                <Td>
+                                  <Split hasGutter>
+                                    {spaProperties.data[identifier].map(({ _id, env }) => (
+                                      <SplitItem key={_id}>
+                                        <Label color="gold" isCompact>
+                                          {env}
+                                        </Label>
+                                      </SplitItem>
+                                    ))}
+                                  </Split>
+                                </Td>
+                              </Tr>
+                              <Tr isExpanded={Boolean(isRowExpanded?.[identifier])}>
+                                <Td colSpan={4} noPadding={false}>
+                                  <ExpandableRowContent>
+                                    <TableComposable
+                                      variant="compact"
+                                      aria-label="expandable-table"
+                                      borders={false}
+                                    >
+                                      <Thead>
+                                        <Tr>
+                                          <Th>Environment Name</Th>
+                                          <Th>Ref</Th>
+                                          <Th>Publish Domain</Th>
+                                          <Th>Internal Access URL</Th>
+                                          <Th>Updated At</Th>
+                                        </Tr>
+                                      </Thead>
+                                      <Tbody>
+                                        {spaProperties?.data?.[identifier].map(
+                                          ({ _id, env, ref, accessUrl, updatedAt }) => (
+                                            <Tr key={_id}>
+                                              <Td>
+                                                <Label color="gold" isCompact>
+                                                  {env}
+                                                </Label>
+                                              </Td>
+                                              <Td>{ref}</Td>
+                                              <Td>
+                                                <a
+                                                  href={`https://${webProperties?.data?.[env]?.url}`}
+                                                  target="_blank"
+                                                  rel="noopener noreferrer"
+                                                >
+                                                  <ExternalLinkAltIcon />{' '}
+                                                  {webProperties?.data?.[env]?.url}
+                                                </a>
+                                              </Td>
 
-                                            <Td>
-                                              <a
-                                                href={accessUrl}
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                              >
-                                                <ExternalLinkAltIcon />{' '}
-                                                {`${accessUrl.slice(0, URL_LENGTH_LIMIT)} ${
-                                                  accessUrl.length > URL_LENGTH_LIMIT ? '...' : ''
-                                                }`}
-                                              </a>
-                                            </Td>
-                                            <Td>
-                                              {formatDate(updatedAt, 'MMM DD, YYYY - hh:mm:ss A')}
-                                            </Td>
-                                          </Tr>
-                                        )
-                                      )}
-                                    </Tbody>
-                                  </TableComposable>
-                                </ExpandableRowContent>
-                              </Td>
-                            </Tr>
+                                              <Td>
+                                                <a
+                                                  href={accessUrl}
+                                                  target="_blank"
+                                                  rel="noopener noreferrer"
+                                                >
+                                                  <ExternalLinkAltIcon />{' '}
+                                                  {`${accessUrl.slice(0, URL_LENGTH_LIMIT)} ${accessUrl.length > URL_LENGTH_LIMIT ? '...' : ''
+                                                    }`}
+                                                </a>
+                                              </Td>
+                                              <Td>
+                                                {formatDate(updatedAt, 'MMM DD, YYYY - hh:mm:ss A')}
+                                              </Td>
+                                            </Tr>
+                                          )
+                                        )}
+                                      </Tbody>
+                                    </TableComposable>
+                                  </ExpandableRowContent>
+                                </Td>
+                              </Tr>
+                            </>}
+
                           </Tbody>
                         ))}
                   </TableComposable>

--- a/packages/manager/src/views/WebPropertyDetailPage/WebPropertyDetailPage.tsx
+++ b/packages/manager/src/views/WebPropertyDetailPage/WebPropertyDetailPage.tsx
@@ -72,7 +72,6 @@ export const WebPropertyDetailPage = (): JSX.Element => {
   const isSpaPropertyListEmpty = spaPropertyKeys.length === 0;
   const webPropertiesKeys = Object.keys(webProperties.data || {});
   const countOfSpas = useGetSPAPropGroupByName(propertyIdentifier, '');
-  console.log("LLL",countOfSpas, webPropertiesKeys)
   const countOfSpasListEmpty = Object.keys(countOfSpas).length === 0;
   useEffect(() => {
     if (spaProperties.isError || webProperties.isError) {
@@ -133,8 +132,8 @@ export const WebPropertyDetailPage = (): JSX.Element => {
             aria-label="SPA listing"
           >
             {!spaProperties.isLoading &&
-              !countOfSpasListEmpty &&
-              Object.values(countOfSpas.data || {}).flat().length === 0 ? (
+            !countOfSpasListEmpty &&
+            Object.values(countOfSpas.data || {}).flat().length === 0 ? (
               <EmptyInfo propertyIdentifier={propertyIdentifier} />
             ) : (
               <>
@@ -214,104 +213,110 @@ export const WebPropertyDetailPage = (): JSX.Element => {
                         .filter((el) => el.toLowerCase().includes(debouncedSearchTerm))
                         .map((identifier, rowIndex) => (
                           <Tbody isExpanded={Boolean(isRowExpanded?.[identifier])} key={identifier}>
-                            
-                            {(spaProperties.isLoading || webProperties.isLoading) ? (
+                            {spaProperties.isLoading || webProperties.isLoading ? (
                               <TableRowSkeleton rows={3} columns={4} />
-                            ) : <>
-                              <Tr isStriped={Boolean(rowIndex % 2)}>
-                                <Td
-                                  expand={{
-                                    rowIndex,
-                                    isExpanded: Boolean(isRowExpanded?.[identifier]),
-                                    onToggle: () => onToggleRowExpanded(identifier),
-                                    expandId: 'composable-property-table'
-                                  }}
-                                />
-                                <Td>
-                                  <Link
-                                    href={{
-                                      pathname: '/properties/[propertyIdentifier]/[spaProperty]',
-                                      query: { propertyIdentifier, spaProperty: identifier }
+                            ) : (
+                              <>
+                                <Tr isStriped={Boolean(rowIndex % 2)}>
+                                  <Td
+                                    expand={{
+                                      rowIndex,
+                                      isExpanded: Boolean(isRowExpanded?.[identifier]),
+                                      onToggle: () => onToggleRowExpanded(identifier),
+                                      expandId: 'composable-property-table'
                                     }}
-                                  >
-                                    {spaProperties.data[identifier]?.[0]?.name}
-                                  </Link>
-                                </Td>
-                                <Td>{spaProperties.data[identifier]?.[0]?.path}</Td>
-                                <Td>
-                                  <Split hasGutter>
-                                    {spaProperties.data[identifier].map(({ _id, env }) => (
-                                      <SplitItem key={_id}>
-                                        <Label color="gold" isCompact>
-                                          {env}
-                                        </Label>
-                                      </SplitItem>
-                                    ))}
-                                  </Split>
-                                </Td>
-                              </Tr>
-                              <Tr isExpanded={Boolean(isRowExpanded?.[identifier])}>
-                                <Td colSpan={4} noPadding={false}>
-                                  <ExpandableRowContent>
-                                    <TableComposable
-                                      variant="compact"
-                                      aria-label="expandable-table"
-                                      borders={false}
+                                  />
+                                  <Td>
+                                    <Link
+                                      href={{
+                                        pathname: '/properties/[propertyIdentifier]/[spaProperty]',
+                                        query: { propertyIdentifier, spaProperty: identifier }
+                                      }}
                                     >
-                                      <Thead>
-                                        <Tr>
-                                          <Th>Environment Name</Th>
-                                          <Th>Ref</Th>
-                                          <Th>Publish Domain</Th>
-                                          <Th>Internal Access URL</Th>
-                                          <Th>Updated At</Th>
-                                        </Tr>
-                                      </Thead>
-                                      <Tbody>
-                                        {spaProperties?.data?.[identifier].map(
-                                          ({ _id, env, ref, accessUrl, updatedAt }) => (
-                                            <Tr key={_id}>
-                                              <Td>
-                                                <Label color="gold" isCompact>
-                                                  {env}
-                                                </Label>
-                                              </Td>
-                                              <Td>{ref}</Td>
-                                              <Td>
-                                                <a
-                                                  href={`https://${webProperties?.data?.[env]?.url}`}
-                                                  target="_blank"
-                                                  rel="noopener noreferrer"
-                                                >
-                                                  <ExternalLinkAltIcon />{' '}
-                                                  {webProperties?.data?.[env]?.url}
-                                                </a>
-                                              </Td>
+                                      {spaProperties.data[identifier]?.[0]?.name}
+                                    </Link>
+                                  </Td>
+                                  <Td>{spaProperties.data[identifier]?.[0]?.path}</Td>
+                                  <Td>
+                                    <Split hasGutter>
+                                      {spaProperties.data[identifier].map(({ _id, env }) => (
+                                        <SplitItem key={_id}>
+                                          <Label color="gold" isCompact>
+                                            {env}
+                                          </Label>
+                                        </SplitItem>
+                                      ))}
+                                    </Split>
+                                  </Td>
+                                </Tr>
+                                <Tr isExpanded={Boolean(isRowExpanded?.[identifier])}>
+                                  <Td colSpan={4} noPadding={false}>
+                                    <ExpandableRowContent>
+                                      <TableComposable
+                                        variant="compact"
+                                        aria-label="expandable-table"
+                                        borders={false}
+                                      >
+                                        <Thead>
+                                          <Tr>
+                                            <Th>Environment Name</Th>
+                                            <Th>Ref</Th>
+                                            <Th>Publish Domain</Th>
+                                            <Th>Internal Access URL</Th>
+                                            <Th>Updated At</Th>
+                                          </Tr>
+                                        </Thead>
+                                        <Tbody>
+                                          {spaProperties?.data?.[identifier].map(
+                                            ({ _id, env, ref, accessUrl, updatedAt }) => (
+                                              <Tr key={_id}>
+                                                <Td>
+                                                  <Label color="gold" isCompact>
+                                                    {env}
+                                                  </Label>
+                                                </Td>
+                                                <Td>{ref}</Td>
+                                                <Td>
+                                                  <a
+                                                    href={`https://${webProperties?.data?.[env]?.url}`}
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                  >
+                                                    <ExternalLinkAltIcon />{' '}
+                                                    {webProperties?.data?.[env]?.url}
+                                                  </a>
+                                                </Td>
 
-                                              <Td>
-                                                <a
-                                                  href={accessUrl}
-                                                  target="_blank"
-                                                  rel="noopener noreferrer"
-                                                >
-                                                  <ExternalLinkAltIcon />{' '}
-                                                  {`${accessUrl.slice(0, URL_LENGTH_LIMIT)} ${accessUrl.length > URL_LENGTH_LIMIT ? '...' : ''
+                                                <Td>
+                                                  <a
+                                                    href={accessUrl}
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                  >
+                                                    <ExternalLinkAltIcon />{' '}
+                                                    {`${accessUrl.slice(0, URL_LENGTH_LIMIT)} ${
+                                                      accessUrl.length > URL_LENGTH_LIMIT
+                                                        ? '...'
+                                                        : ''
                                                     }`}
-                                                </a>
-                                              </Td>
-                                              <Td>
-                                                {formatDate(updatedAt, 'MMM DD, YYYY - hh:mm:ss A')}
-                                              </Td>
-                                            </Tr>
-                                          )
-                                        )}
-                                      </Tbody>
-                                    </TableComposable>
-                                  </ExpandableRowContent>
-                                </Td>
-                              </Tr>
-                            </>}
-
+                                                  </a>
+                                                </Td>
+                                                <Td>
+                                                  {formatDate(
+                                                    updatedAt,
+                                                    'MMM DD, YYYY - hh:mm:ss A'
+                                                  )}
+                                                </Td>
+                                              </Tr>
+                                            )
+                                          )}
+                                        </Tbody>
+                                      </TableComposable>
+                                    </ExpandableRowContent>
+                                  </Td>
+                                </Tr>
+                              </>
+                            )}
                           </Tbody>
                         ))}
                   </TableComposable>


### PR DESCRIPTION
<!--
Follow the steps to create the PR:

Subject: "feat/fix/docs(#issue_id): <PR Subject>"
Assignees: "Developers"
Projects: ""
-->

## Closes / Fixes / Resolves

<!-- Comman separated list of GitHub Issue ID(s) -->

## Explain the feature/fix
Fixes the bug where filter was not visible in web property where we have envs with spas and no spas.
<!-- Provide a clear explaination of the feature/fix implemented -->

## Does this PR introduce a breaking change

<!-- Yes/No -->
No
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->

## Screenshot(s)

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

<!-- Add your screenshot(s) below this line -->
New web property/ only ephemeral view deployed : no filter should be visible

![image](https://user-images.githubusercontent.com/26894183/213116658-c50388f9-8c01-4380-82ff-73edc5630b4b.png)


spas are deployed on other envs and not on one envs : Filter should be visible
<img width="1426" alt="image" src="https://user-images.githubusercontent.com/26894183/213116796-f8915611-b4fe-4fd4-8fda-2d8103cf9def.png">

<img width="1426" alt="image" src="https://user-images.githubusercontent.com/26894183/213116850-76f5542e-22e0-41cf-9bd5-2fc76c59cf3e.png">

</details>

### Ready-for-merge Checklist

- [ ] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Does the change have appropriate unit tests?
- [ ] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [ ] Was this feature demo'd and the design review approved?
