### PR TITLE
fix(manager): Fixing the Line chart color inconsistency issue

### DIFF
--- a/packages/manager/src/services/analytics/queries.tsx
+++ b/packages/manager/src/services/analytics/queries.tsx
@@ -162,14 +162,14 @@ export const useGetMonthlyDeploymentChartWithEphemeral = () =>
       qa?: IDeploymentData[];
       stage?: IDeploymentData[];
       dev?: IDeploymentData[];
-      uatprod?: IDeploymentData[];
+      prod?: IDeploymentData[];
       ephemeral?: IDeploymentData[];
     }) => {
       const monthlyDelpoymentData: {
         qa?: any[];
         stage?: any[];
         dev?: any[];
-        uatprod?: any[];
+        prod?: any[];
         lastMonthEphemeral?: number;
         maxDeploymentCount?: number;
         minDeploymentCount?: number;
@@ -177,20 +177,20 @@ export const useGetMonthlyDeploymentChartWithEphemeral = () =>
       monthlyDelpoymentData.qa = sortWeeklyDeployments(data.qa || []);
       monthlyDelpoymentData.stage = sortWeeklyDeployments(data.stage || []);
       monthlyDelpoymentData.dev = sortWeeklyDeployments(data.dev || []);
-      monthlyDelpoymentData.uatprod = sortWeeklyDeployments(data.uatprod || []);
+      monthlyDelpoymentData.prod = sortWeeklyDeployments(data.prod || []);
       monthlyDelpoymentData.lastMonthEphemeral =
         data.ephemeral?.reduce((acc, obj) => acc + obj.count, 0) || 0;
       monthlyDelpoymentData.minDeploymentCount = Math.min(
         data.qa?.reduce((acc, obj) => Math.min(acc, obj.count), data?.qa?.[0]?.count) || 0,
         data.stage?.reduce((acc, obj) => Math.min(acc, obj.count), data?.stage?.[0]?.count) || 0,
         data.dev?.reduce((acc, obj) => Math.min(acc, obj.count), data?.dev?.[0]?.count) || 0,
-        data.uatprod?.reduce((acc, obj) => Math.min(acc, obj.count), data?.uatprod?.[0]?.count) || 0
+        data.prod?.reduce((acc, obj) => Math.min(acc, obj.count), data?.prod?.[0]?.count) || 0
       );
       monthlyDelpoymentData.maxDeploymentCount = Math.max(
         data.qa?.reduce((acc, obj) => Math.max(acc, obj.count), 0) || 0,
         data.stage?.reduce((acc, obj) => Math.max(acc, obj.count), 0) || 0,
         data.dev?.reduce((acc, obj) => Math.max(acc, obj.count), 0) || 0,
-        data.uatprod?.reduce((acc, obj) => Math.max(acc, obj.count), 0) || 0
+        data.prod?.reduce((acc, obj) => Math.max(acc, obj.count), 0) || 0
       );
       return monthlyDelpoymentData;
     }

--- a/packages/manager/src/views/DashboardPage/DashboardPage.tsx
+++ b/packages/manager/src/views/DashboardPage/DashboardPage.tsx
@@ -31,7 +31,7 @@ export const DashboardPage = (): JSX.Element => {
       <div style={{ width: '55%' }}>
         <Analytics
           QAData={TotalMonthlyDeploymentData?.qa}
-          ProdData={TotalMonthlyDeploymentData?.uatprod}
+          ProdData={TotalMonthlyDeploymentData?.prod}
           DevData={TotalMonthlyDeploymentData?.dev}
           StageData={TotalMonthlyDeploymentData?.stage}
           Totaldeployment={Totaldeployment}

--- a/packages/manager/src/views/DashboardPage/components/Analytics/Analytics.tsx
+++ b/packages/manager/src/views/DashboardPage/components/Analytics/Analytics.tsx
@@ -203,19 +203,13 @@ export const Analytics = ({
         <div style={{ height: '275px' }}>
           <Chart
             ariaDesc="Average number of pets"
-            ariaTitle="Line chart example"
             containerComponent={
               <ChartVoronoiContainer
                 labels={({ datum }) => `${datum.name}: ${datum.y}`}
                 constrainToVisibleArea
               />
             }
-            legendData={[
-              { name: 'Prod' },
-              { name: 'Stage', symbol: { type: 'dash' } },
-              { name: 'QA' },
-              { name: 'Dev' }
-            ]}
+            legendData={[{ name: 'prod' }, { name: 'dev' }, { name: 'qa' }, { name: 'stage' }]}
             legendPosition="bottom-left"
             height={275}
             maxDomain={{ y: maxCount + (maxCount - minCount) * 0.2 }}
@@ -239,8 +233,8 @@ export const Analytics = ({
             <ChartGroup>
               {ProdData && <ChartLine data={ProdData} />}
               {StageData && <ChartLine data={StageData} />}
-              {QAData && <ChartLine data={QAData} />}
               {DevData && <ChartLine data={DevData} />}
+              {QAData && <ChartLine data={QAData} />}
             </ChartGroup>
           </Chart>
         </div>


### PR DESCRIPTION
<!--
Follow the steps to create the PR:

Subject: "feat/fix/docs(#issue_id): <PR Subject>"
Assignees: "Developers"
Projects: ""
-->

## Closes / Fixes / Resolves
SPASHIP-1119
<!-- Comman separated list of GitHub Issue ID(s) -->

## Explain the feature/fix
Syncing the graph legend color to the color of lines. Putting prod instead of UAT prod in the graph. 
<!-- Provide a clear explaination of the feature/fix implemented -->

## Does this PR introduce a breaking change

No 

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->

## Screenshot(s)

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

<!-- Add your screenshot(s) below this line -->
![image](https://user-images.githubusercontent.com/55888723/214562394-42a6098a-f60a-4044-bb89-cc28870c008d.png)

</details>
