### PR TITLE
feat(api) : group permission result with Owner & User segregation 

### DIFF
--- a/packages/api/src/server/permission/permission.controller.ts
+++ b/packages/api/src/server/permission/permission.controller.ts
@@ -18,10 +18,11 @@ export class PermissionController {
     @Query('name') name: string,
     @Query('email') email: string,
     @Query('action') action: string,
+    @Query('group') group: string,
     @Query('skip') skip: number,
     @Query('limit') limit: number
   ) {
-    return this.permissionService.getPermissions(propertyIdentifier, name, email, action, skip, limit);
+    return this.permissionService.getPermissions(propertyIdentifier, name, email, action, group, skip, limit);
   }
 
   @Post()

--- a/packages/api/src/server/permission/service/permission.factory.ts
+++ b/packages/api/src/server/permission/service/permission.factory.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { ROLE } from 'src/server/role/role.entity';
 import { CreatePermissionDto, DeletePermissionDto } from '../permission.dto';
 import { Permission } from '../permission.entity';
 
@@ -33,5 +34,24 @@ export class PermissionFactory {
       }
     }
     return permissions;
+  }
+
+  groupPermission(permissions: Permission[], matchRole: number) {
+    const groupedPermissions = permissions.reduce((acc, obj) => {
+      const key = obj.email;
+      const group = acc[key] ?? [];
+      return { ...acc, [key]: [...group, obj] };
+    }, {});
+    const emails = Array.from(new Set(permissions.map((item) => item.email)));
+    const groupedResponse = [];
+    for (const item of emails) {
+      const data = {
+        email: item,
+        role: groupedPermissions[item].length === matchRole ? ROLE.OWNER : ROLE.USER,
+        details: groupedPermissions[item]
+      };
+      groupedResponse.push(data);
+    }
+    return groupedResponse;
   }
 }

--- a/packages/api/src/server/role/role.entity.ts
+++ b/packages/api/src/server/role/role.entity.ts
@@ -5,3 +5,8 @@ export class Role {
 
   isActive: boolean;
 }
+
+export enum ROLE {
+  OWNER = 'OWNER',
+  USER = 'USER'
+}


### PR DESCRIPTION
Subject: feat(api) : group permission result based on email
Assignees: @soumyadip007 

## Closes / Fixes 

1. Grouping added for RBAC Results based on email
2. Segregate Owner & User based on the Permission
3. Grouping Specifier added (email) in the request query

## Does this PR introduce a breaking change

NO

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->

## Screenshot(s)

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

<!-- Add your screenshot(s) below this line -->

</details>

### Ready-for-merge Checklist

- [ ] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Does the change have appropriate unit tests?
- [ ] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [ ] Was this feature demo'd and the design review approved?
