### PR TITLE
fix(api) : activity stream fixed for RBAC Creation

### DIFF
--- a/packages/api/src/server/permission/service/permission.service.ts
+++ b/packages/api/src/server/permission/service/permission.service.ts
@@ -22,7 +22,7 @@ export class PermissionService {
     private readonly permissionFactory: PermissionFactory,
     private readonly loggerService: LoggerService,
     private readonly analyticsService: AnalyticsService
-  ) { }
+  ) {}
 
   /* @internal
    * Get the list of the Permissions
@@ -73,13 +73,13 @@ export class PermissionService {
         this.loggerService.error('CreatePermissions', err);
       }
     }
-    for (const tmpPermission of createPermissionDto.permissionDetails) {
+    for (const tmpPermission of savedPermissions) {
       await this.analyticsService.createActivityStream(
         createPermissionDto.propertyIdentifier,
         Action.PERMISSION_CREATED,
         'NA',
         'NA',
-        `${tmpPermission.actions.toString()} access provided for ${tmpPermission.email}`,
+        `${tmpPermission.action} access provided for ${tmpPermission.email}`,
         createPermissionDto.createdBy,
         Source.MANAGER,
         JSON.stringify(tmpPermission)
@@ -123,7 +123,7 @@ export class PermissionService {
             Action.PERMISSION_DELETED,
             'NA',
             'NA',
-            `${permission.action.toString()} access deleted for ${permission.email}`,
+            `${permission.action} access removed for ${permission.email}`,
             deletePermissionDto.createdBy,
             Source.MANAGER,
             JSON.stringify(permission)


### PR DESCRIPTION
Subject:  fix(api) : activity stream fixed for RBAC Creation
Assignees: @soumyadip007 

## Closes / Fixes 

1. Duplicated Records issue resolved for activity stream on Permission creation
2. Add only Newly Created Permissions in the Activity Stream
3. Activity stream message formatted

## Does this PR introduce a breaking change

NO

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->

## Screenshot(s)

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

<!-- Add your screenshot(s) below this line -->

</details>

### Ready-for-merge Checklist

- [ ] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Does the change have appropriate unit tests?
- [ ] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [ ] Was this feature demo'd and the design review approved?
