### PR TITLE
feat(manager) : Added domains for each property on Web Property List Page

### DIFF
--- a/packages/manager/src/services/webProperty/types.ts
+++ b/packages/manager/src/services/webProperty/types.ts
@@ -1,17 +1,23 @@
 export type TWebProperty = {
-  _id: string;
+  env: [
+    {
+      _id: string;
+      cluster: string;
+      createdAt: string;
+      createdBy: string;
+      env: string;
+      isActive: boolean;
+      isEph: boolean;
+      propertyIdentifier: string;
+      sync: string;
+      updatedAt: string;
+      updatedBy: string;
+      url: string;
+    }
+  ];
+  createdBy: string;
   title: string;
   identifier: string;
-  cluster: string;
-  isEph: boolean;
-  url: string;
-  env: string;
-  type: string;
-  createdBy: string;
-  isActive: boolean;
-  createdAt: string;
-  updatedAt: string;
-  id: string;
 };
 
 export type TCreateWebPropertyDTO = {

--- a/packages/manager/src/services/webProperty/types.ts
+++ b/packages/manager/src/services/webProperty/types.ts
@@ -1,20 +1,18 @@
 export type TWebProperty = {
-  env: [
-    {
-      _id: string;
-      cluster: string;
-      createdAt: string;
-      createdBy: string;
-      env: string;
-      isActive: boolean;
-      isEph: boolean;
-      propertyIdentifier: string;
-      sync: string;
-      updatedAt: string;
-      updatedBy: string;
-      url: string;
-    }
-  ];
+  env: {
+    _id: string;
+    cluster: string;
+    createdAt: string;
+    createdBy: string;
+    env: string;
+    isActive: boolean;
+    isEph: boolean;
+    propertyIdentifier: string;
+    sync: string;
+    updatedAt: string;
+    updatedBy: string;
+    url: string;
+  }[];
   createdBy: string;
   title: string;
   identifier: string;

--- a/packages/manager/src/views/WebPropertyListPage/WebPropertyListPage.tsx
+++ b/packages/manager/src/views/WebPropertyListPage/WebPropertyListPage.tsx
@@ -42,6 +42,7 @@ export const WebPropertyListPage = (): JSX.Element => {
   const debouncedSearchTerm = useDebounce(searchTerm, 200);
 
   const webProperties = useGetWebProperties();
+
   const webPropertyDeloymentCount = useGetDeploymentCounts();
 
   // loading state skeletion cards
@@ -153,7 +154,7 @@ export const WebPropertyListPage = (): JSX.Element => {
             </GalleryItem>
             {/* List of Properties */}
             {filteredWebProperties?.map(
-              ({ identifier, title, url, createdBy }: Partial<TWebProperty>) => (
+              ({ identifier, title, createdBy, env }: Partial<TWebProperty>) => (
                 <GalleryItem key={identifier}>
                   <Link
                     href={{
@@ -164,7 +165,11 @@ export const WebPropertyListPage = (): JSX.Element => {
                     <a className="text-decoration-none">
                       <WebPropertyCard
                         title={title}
-                        subtitle={url}
+                        subtitle={
+                          env?.find((x) => x.env === 'prod')?.url ||
+                          env?.find((x) => x.env === 'stage')?.url ||
+                          env?.at(0)?.url
+                        }
                         isSelected={createdBy === session?.user?.email}
                         footer={`${
                           webPropertyDeloymentCount?.data?.[identifier || ''] || 0

--- a/packages/manager/src/views/WebPropertyListPage/WebPropertyListPage.tsx
+++ b/packages/manager/src/views/WebPropertyListPage/WebPropertyListPage.tsx
@@ -166,8 +166,8 @@ export const WebPropertyListPage = (): JSX.Element => {
                       <WebPropertyCard
                         title={title}
                         subtitle={
-                          env?.find((x) => x.env === 'prod')?.url ||
-                          env?.find((x) => x.env === 'stage')?.url ||
+                          env?.find((envArray) => envArray.env === 'prod')?.url ||
+                          env?.find((envArray) => envArray.env === 'stage')?.url ||
                           env?.at(0)?.url
                         }
                         isSelected={createdBy === session?.user?.email}

--- a/packages/manager/src/views/WebPropertyListPage/components/WebPropertyCard/WebPropertyCard.tsx
+++ b/packages/manager/src/views/WebPropertyListPage/components/WebPropertyCard/WebPropertyCard.tsx
@@ -24,7 +24,7 @@ export const WebPropertyCard = ({ title, subtitle, children, footer, isSelected 
       <Title headingLevel="h3" size="xl" className="capitalize">
         {title}
       </Title>
-      <Text component="small" className="pf-u-color-400">
+      <Text component="h1" style={{ fontSize: '20px', marginTop: '10px', color: '#F4C145' }}>
         {subtitle}
       </Text>
     </CardTitle>

--- a/packages/manager/src/views/WebPropertyListPage/components/WebPropertyCard/WebPropertyCard.tsx
+++ b/packages/manager/src/views/WebPropertyListPage/components/WebPropertyCard/WebPropertyCard.tsx
@@ -24,7 +24,10 @@ export const WebPropertyCard = ({ title, subtitle, children, footer, isSelected 
       <Title headingLevel="h3" size="xl" className="capitalize">
         {title}
       </Title>
-      <Text component="h1" style={{ fontSize: '20px', marginTop: '10px', color: '#F4C145' }}>
+      <Text
+        component="h1"
+        style={{ fontSize: '16px', marginTop: '10px', color: '#808080', fontWeight: 500 }}
+      >
         {subtitle}
       </Text>
     </CardTitle>


### PR DESCRIPTION
## Explain the feature/fix

Domain is mentioned for property over individual boxes for Property. (Web Properties page).
- In a Web property, we can have multiple Environments with mapped domains / hosted urls.
- Mentioned domain of Prod in most cases, if no prod environment then stage is shown.
- In case there is neither prod nor stage the first env present in the list is shown.

## Does this PR introduce a breaking change

No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->

## Screenshot(s)
![Screenshot from 2023-02-16 14-10-48](https://user-images.githubusercontent.com/56580582/219316704-0ae59109-4a64-4b86-9fe1-d2d73b205cb8.png)

![Screenshot from 2023-02-20 10-25-30](https://user-images.githubusercontent.com/56580582/220013986-7178dd48-8a57-4383-9986-abc3c550bcd1.png)


