### PR TITLE
feat(manager): SPAship Banner Made Dynamic

### DIFF
--- a/packages/manager/src/layouts/AppLayout/AppLayout.tsx
+++ b/packages/manager/src/layouts/AppLayout/AppLayout.tsx
@@ -6,6 +6,7 @@ import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { SideBar } from './components/SideBar';
 import { Nav } from './components/Nav';
 import { Footer } from './components/Footer';
+import { useGetDocumentPage } from '@app/services/documents';
 
 interface Props {
   children: ReactNode;
@@ -15,33 +16,65 @@ interface Props {
  * TODO: Breadcrumb generator to be building using a context
  * TODO: The title for layout should be changing based on URLs or can be from a context
  */
-export const AppLayout = ({ children }: Props): JSX.Element => (
+export const AppLayout = ({ children }: Props): JSX.Element => {
+  const data = useGetDocumentPage();
+  const sections = Object.keys(data?.data || {}).filter((section) => section === 'banner');
+  const lastSection = sections[sections.length - 1];
+  const lastSectionData = data?.data?.[lastSection] ?? [];
+  const lastElement = lastSectionData[lastSectionData.length - 1] ?? null;
+  const isOutage = lastElement && lastElement.tags?.includes('outage') || false;
+  
+  return (
   <>
-    <Banner
-      style={{
-        backgroundColor: 'var(--spaship-global--Color--solar-orange)'
-      }}
-      isSticky
-      variant="info"
-    >
-      <Flex
-        justifyContent={{ default: 'justifyContentCenter' }}
-        alignItems={{ default: 'alignItemsCenter' }}
+
+{lastElement && !isOutage && (
+      <Banner
+        style={{
+          backgroundColor: 'var(--spaship-global--Color--solar-orange)'
+        }}
+        isSticky
+        variant="info"
       >
-        <a
-          target="_blank"
-          href="https://source.redhat.com/groups/public/spaship/blog_article/whats_new_in_spaship_"
-          rel="noreferrer"
+        <Flex
+          justifyContent={{ default: 'justifyContentCenter' }}
+          alignItems={{ default: 'alignItemsCenter' }}
         >
-          <ExternalLinkAltIcon
-            style={{
-              marginRight: '0.5rem'
-            }}
-          />
-          What&apos;s new in SPAship?
-        </a>
-      </Flex>
-    </Banner>
+          <a
+            target="_blank"
+            href={lastElement.link}
+            rel="noreferrer"
+          >
+            <ExternalLinkAltIcon
+              style={{
+                marginRight: '0.5rem'
+              }}
+            />
+            {lastElement.title}
+          </a>
+        </Flex>
+      </Banner>
+    )}
+    {lastElement &&isOutage && (
+       <Banner
+       style={{
+         backgroundColor: '#F44336',
+         color: '#FFFFFF',
+         fontWeight:'bolder'
+         
+       }}
+       isSticky
+       variant="info"
+     >
+       <Flex
+         justifyContent={{ default: 'justifyContentCenter' }}
+         alignItems={{ default: 'alignItemsCenter' }}
+       >
+         
+           {lastElement.title}
+          
+       </Flex>
+     </Banner>
+    )}
     <Page sidebar={<SideBar />} header={<Nav />}>
       <Flex
         direction={{ default: 'column' }}
@@ -56,6 +89,7 @@ export const AppLayout = ({ children }: Props): JSX.Element => (
       </Flex>
     </Page>
   </>
-);
+  );
+};
 
 export const getAppLayout = (page: JSX.Element) => <AppLayout>{page}</AppLayout>;

--- a/packages/manager/src/views/DocumentsPage/DocumentsPage.tsx
+++ b/packages/manager/src/views/DocumentsPage/DocumentsPage.tsx
@@ -5,10 +5,11 @@ import { DocumentCard } from './components/DocumentCard';
 
 export const DocumentsPage = (): JSX.Element => {
   const data = useGetDocumentPage();
+  const sections = Object.keys(data?.data || {}).filter((section) => section !== 'banner');
   return (
     <>
       <Banner title="Documents" />
-      {Object.keys(data?.data || {}).map((section) => (
+      {sections.map((section) => (
         <>
           <Title headingLevel="h1" style={{ marginLeft: '100px', marginTop: '20px' }}>
             {section}


### PR DESCRIPTION

## Explain the feature/fix

Replaced the static Banner with Dynamic to update it automatically and show messages of outages if needed from the API directly.

- If No outage showing Default What's new in SPAship else showing the Outage Message 

## Does this PR introduce a breaking change

No

## Screenshot(s)

![Screenshot from 2023-04-17 14-49-52](https://user-images.githubusercontent.com/56580582/232465548-6caa0910-8621-439a-8b40-f320c2312ffa.png)
![Screenshot from 2023-04-17 14-50-51](https://user-images.githubusercontent.com/56580582/232465573-4dc908e4-15c0-494f-9f0f-b83fdce2f874.png)



