### PR TITLE
feat(api) : CORS configs added into env

### DIFF
--- a/packages/api/src/configuration/index.ts
+++ b/packages/api/src/configuration/index.ts
@@ -32,6 +32,15 @@ function getDatabaseConfiguration() {
 export const DATA_BASE_CONFIGURATION = {
   mongoConnectionString: getDatabaseConfiguration()
 };
+export const ALLOWED_ORIGIN = {
+  hosts: getAllowedOrigins()
+};
+
+function getAllowedOrigins() {
+  const hosts = process.env.SPASHIP_ALLOWED_ORIGINS;
+  if (hosts) return hosts.split(',');
+  return ['http://localhost:2468'];
+}
 
 export const AUTH_LISTING = {
   deploymentBaseURL: '/api/v1/applications/deploy',

--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -3,7 +3,7 @@ import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import * as cookieParser from 'cookie-parser';
 import { AppModule } from './app.module';
-import { ENV, ENV_TYPE, SPASHIP_VERSION } from './configuration';
+import { ALLOWED_ORIGIN, ENV, ENV_TYPE, SPASHIP_VERSION } from './configuration';
 import { LoggingInterceptor } from './configuration/interceptors/logger.interceptor';
 import { ResponseFormat, ResponseInterceptor } from './configuration/interceptors/response.interceptor';
 import { LoggerService } from './configuration/logger/logger.service';
@@ -44,7 +44,7 @@ async function bootstrap() {
     });
     SwaggerModule.setup('api-docs', app, document);
     app.enableCors({
-      origin: ['http://localhost:2468'],
+      origin: ALLOWED_ORIGIN.hosts,
       methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS'
     });
   }

--- a/packages/api/src/server/health/service/health.module.ts
+++ b/packages/api/src/server/health/service/health.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
 import { TerminusModule } from '@nestjs/terminus';
-import { HealthController } from '../health.controller';
 import { HealthService } from './health.service';
 
 @Module({


### PR DESCRIPTION
Subject:  feat(api) : CORS configs added into env
Assignees: @soumyadip007 

## Closes / Fixes 

1. Read cors config from the env varaibles
2. Used the existing cors config, localhost:2468 (manager) set to default
3. Lint fixed

## Does this PR introduce a breaking change

NO

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->

## Screenshot(s)

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

<!-- Add your screenshot(s) below this line -->

</details>

### Ready-for-merge Checklist

- [ ] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Does the change have appropriate unit tests?
- [ ] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [ ] Was this feature demo'd and the design review approved?
