### PR TITLE
feat(api) : deployment hour saved api added for the login screen

### DIFF
--- a/packages/api/src/configuration/index.ts
+++ b/packages/api/src/configuration/index.ts
@@ -46,7 +46,8 @@ export const AUTH_LISTING = {
   deploymentBaseURL: '/api/v1/applications/deploy',
   eventsBaseURL: '/api/v1/analytics/events',
   propertyBaseURL: '/api/v1/property',
-  gitDeploymentBaseURL: '/api/v1/applications/git/deploy'
+  gitDeploymentBaseURL: '/api/v1/applications/git/deploy',
+  hourSavedAnalyticsBaseURL: '/api/v1/analytics/deployment/time-saved'
 };
 
 const ROVER_AUTH_DETAILS = {

--- a/packages/api/src/server/analytics/analytics.controller.ts
+++ b/packages/api/src/server/analytics/analytics.controller.ts
@@ -80,4 +80,11 @@ export class AnalyticsController {
   async getDeveloperMetrics(@Query('month') month: string, @Query('cluster') cluster: string, @Query('type') type: string): Promise<any> {
     return this.analyticsService.getDeveloperMetrics(Number(month), cluster, type);
   }
+
+  @Get('/deployment/time-saved')
+  @ApiCreatedResponse({ status: 200, description: 'Get the Average time for the Deployments saved by SPAship.', type: DeploymentTime })
+  @ApiOperation({ description: 'Get the Average time for the Deployments saved by SPAship.' })
+  async getAverageDeploymentTimeSaved(): Promise<any> {
+    return this.analyticsService.getDeploymentTimeSaved();
+  }
 }

--- a/packages/api/src/server/auth/auth.guard.ts
+++ b/packages/api/src/server/auth/auth.guard.ts
@@ -22,8 +22,9 @@ export class AuthenticationGuard extends AuthGuard('jwt') {
    * Token Format : Bearer {JWT} / Bearer {APIKey}
    */
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    // @internal TODO : To be removed after the auth implementation in the Puzzle Application
-    if (context.getArgs()[0].url.startsWith(AUTH_LISTING.gitDeploymentBaseURL)) return true;
+    // @internal TODO : auth to be implemented for the Puzzle Application
+    // @internal no auth for hourSavedAnalyticsBaseURL, added in the login screen
+    if (context.getArgs()[0].url.startsWith(AUTH_LISTING.hourSavedAnalyticsBaseURL)) return true;
     let bearerToken: string;
     try {
       /* eslint-disable prefer-destructuring */


### PR DESCRIPTION
Subject:  feat(api) : deployment hour saved api added for the login screen
Assignees: @soumyadip007 

## Closes / Fixes 

1.  Deployment hour saved api (get) added for the login screen
2. As login screen doesn't have any auth, so we've removed the auth for this specific api (only send the hours)

## Does this PR introduce a breaking change

NO

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->

## Screenshot(s)

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

<!-- Add your screenshot(s) below this line -->

</details>

### Ready-for-merge Checklist

- [ ] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Does the change have appropriate unit tests?
- [ ] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [ ] Was this feature demo'd and the design review approved?
