### PR TITLE
chore(api) : cmdb code validation & default code process, eph env duration limit

### DIFF
--- a/packages/api/src/configuration/index.ts
+++ b/packages/api/src/configuration/index.ts
@@ -119,7 +119,7 @@ export enum MESSAGE {
   INVALID_ENV = 'Invalid Environment [Correct format : prod, stage, dev]',
   INVALID_LABEL = 'Invalid Label [Correct format : all-access, prod-key].',
   INVALID_IMAGEURL = 'Invalid Image URL. Please check the image url',
-  INVALID_EPHEXPIRESIN = "The time isn't right – Duration for the Ephemeral Environment needs to be between 1 and 500 hours.",
+  INVALID_EPHEXPIRESIN = "The duration for the Ephemeral Environment must be between 1 and 500 hours.",
   INVALID_CMDB_CODE = 'Invalid CMDB Code.',
   INVALID_SEVERITY = 'Invalid Severity.'
 }

--- a/packages/api/src/configuration/index.ts
+++ b/packages/api/src/configuration/index.ts
@@ -3,7 +3,8 @@ export const DIRECTORY_CONFIGURATION = {
 };
 
 export const EPHEMERAL_ENV = {
-  expiresIn: process.env.SPASHIP_EPHEMERAL_EXPIRES_IN || 3600
+  expiresIn: process.env.SPASHIP_EPH__TTL || 3600,
+  maximumDuration: process.env.SPASHIP_EPH__MAX_DURATION || 500
 };
 
 export const CONTAINERIZED_DEPLOYMENT_DETAILS = {
@@ -118,7 +119,7 @@ export enum MESSAGE {
   INVALID_ENV = 'Invalid Environment [Correct format : prod, stage, dev]',
   INVALID_LABEL = 'Invalid Label [Correct format : all-access, prod-key].',
   INVALID_IMAGEURL = 'Invalid Image URL. Please check the image url',
-  INVALID_EPHEXPIRESIN = 'Time is Invalid',
+  INVALID_EPHEXPIRESIN = 'Time is Invalid, duration for the Ephemeral Environment should be with in 1-500 hr.',
   INVALID_CMDB_CODE = 'Invalid CMDB Code.',
   INVALID_SEVERITY = 'Invalid Severity.'
 }

--- a/packages/api/src/configuration/index.ts
+++ b/packages/api/src/configuration/index.ts
@@ -119,7 +119,7 @@ export enum MESSAGE {
   INVALID_ENV = 'Invalid Environment [Correct format : prod, stage, dev]',
   INVALID_LABEL = 'Invalid Label [Correct format : all-access, prod-key].',
   INVALID_IMAGEURL = 'Invalid Image URL. Please check the image url',
-  INVALID_EPHEXPIRESIN = 'Time is Invalid, duration for the Ephemeral Environment should be with in 1-500 hr.',
+  INVALID_EPHEXPIRESIN = "The time isn't right – Duration for the Ephemeral Environment needs to be between 1 and 500 hours.",
   INVALID_CMDB_CODE = 'Invalid CMDB Code.',
   INVALID_SEVERITY = 'Invalid Severity.'
 }

--- a/packages/api/src/server/agenda/agenda.module.ts
+++ b/packages/api/src/server/agenda/agenda.module.ts
@@ -13,6 +13,8 @@ import { PermissionFactory } from '../permission/service/permission.factory';
 import { PermissionService } from '../permission/service/permission.service';
 import { PropertyFactory } from '../property/service/property.factory';
 import { PropertyService } from '../property/service/property.service';
+import { CMDBFactory } from '../sot/cmdb/service/cmdb.factory';
+import { CMDBService } from '../sot/cmdb/service/cmdb.service';
 import { AgendaService } from './agenda.service';
 
 @Module({
@@ -30,7 +32,9 @@ import { AgendaService } from './agenda.service';
     PropertyService,
     PropertyFactory,
     PermissionService,
-    PermissionFactory
+    PermissionFactory,
+    CMDBService,
+    CMDBFactory
   ],
   exports: [AgendaService]
 })

--- a/packages/api/src/server/application/application.controller.ts
+++ b/packages/api/src/server/application/application.controller.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Delete, Get, Param, Post, Query, UploadedFile, UseGuards, UseInterceptors } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
-import { DIRECTORY_CONFIGURATION, EPHEMERAL_ENV, MESSAGE } from '../../configuration';
+import { DIRECTORY_CONFIGURATION } from '../../configuration';
 import { AuthenticationGuard } from '../auth/auth.guard';
 import { ExceptionsService } from '../exceptions/exceptions.service';
 import {
@@ -78,13 +78,7 @@ export class ApplicationController {
     if (!file?.originalname) this.exceptionService.badRequestException({ message: 'Please provide a valid file for the deployment.' });
     const fileFilter = file?.originalname.split('.');
     if (!types.includes(fileFilter[fileFilter.length - 1])) this.exceptionService.badRequestException({ message: 'Invalid file type.' });
-    if (
-      applicationDto.ephemeral &&
-      applicationDto.expiresIn &&
-      (Number(applicationDto.expiresIn) < 1 || Number(applicationDto.expiresIn) > Number(EPHEMERAL_ENV.maximumDuration))
-    ) {
-      this.exceptionService.badRequestException({ message: MESSAGE.INVALID_EPHEXPIRESIN });
-    }
+    this.applicationFactory.validateEphemeralRequestForDuration(applicationDto);
     const application = this.applicationService.saveApplication(applicationDto, file.path, params.propertyIdentifier, params.env, queries.createdBy);
     return application;
   }

--- a/packages/api/src/server/application/application.controller.ts
+++ b/packages/api/src/server/application/application.controller.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Delete, Get, Param, Post, Query, UploadedFile, UseGuards, UseInterceptors } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
-import { DIRECTORY_CONFIGURATION } from '../../configuration';
+import { DIRECTORY_CONFIGURATION, EPHEMERAL_ENV, MESSAGE } from '../../configuration';
 import { AuthenticationGuard } from '../auth/auth.guard';
 import { ExceptionsService } from '../exceptions/exceptions.service';
 import {
@@ -78,6 +78,13 @@ export class ApplicationController {
     if (!file?.originalname) this.exceptionService.badRequestException({ message: 'Please provide a valid file for the deployment.' });
     const fileFilter = file?.originalname.split('.');
     if (!types.includes(fileFilter[fileFilter.length - 1])) this.exceptionService.badRequestException({ message: 'Invalid file type.' });
+    if (
+      applicationDto.ephemeral &&
+      applicationDto.expiresIn &&
+      (Number(applicationDto.expiresIn) < 1 || Number(applicationDto.expiresIn) > Number(EPHEMERAL_ENV.maximumDuration))
+    ) {
+      this.exceptionService.badRequestException({ message: MESSAGE.INVALID_EPHEXPIRESIN });
+    }
     const application = this.applicationService.saveApplication(applicationDto, file.path, params.propertyIdentifier, params.env, queries.createdBy);
     return application;
   }

--- a/packages/api/src/server/application/application.dto.ts
+++ b/packages/api/src/server/application/application.dto.ts
@@ -27,7 +27,7 @@ export class CreateApplicationDto {
   @ApiProperty()
   @IsString()
   @IsOptional()
-  @Length(MIN.EPH_EXPIRESIN, MAX.EPH_EXPIRESIN, { message: MESSAGE.INVALID_LENGTH, always: true })
+  @Length(MIN.EPH_EXPIRESIN, MAX.EPH_EXPIRESIN, { message: MESSAGE.INVALID_EPHEXPIRESIN, always: true })
   @Matches(VALIDATION.EPH_EXPIRESIN, { message: MESSAGE.INVALID_EPHEXPIRESIN, always: true })
   expiresIn: string;
 

--- a/packages/api/src/server/application/service/application.factory.ts
+++ b/packages/api/src/server/application/service/application.factory.ts
@@ -812,7 +812,7 @@ export class ApplicationFactory {
   validateEphemeralRequestForDuration(applicationDto: CreateApplicationDto) {
     const expiresIn = Number(applicationDto?.expiresIn);
     const maxDuration = Number(EPHEMERAL_ENV.maximumDuration);
-    const isEphemeralWithCustomDuration = applicationDto.ephemeral && expiresIn;
+    const isEphemeralWithCustomDuration = applicationDto?.ephemeral && expiresIn;
     if (isEphemeralWithCustomDuration && (expiresIn < 1 || expiresIn > maxDuration)) {
       this.exceptionService.badRequestException({ message: MESSAGE.INVALID_EPHEXPIRESIN });
     }

--- a/packages/api/src/server/application/service/application.factory.ts
+++ b/packages/api/src/server/application/service/application.factory.ts
@@ -5,7 +5,7 @@ import * as FormData from 'form-data';
 import * as fs from 'fs';
 import { Base64 } from 'js-base64';
 import * as path from 'path';
-import { CONTAINERIZED_DEPLOYMENT_DETAILS, DEPLOYMENT_DETAILS, DIRECTORY_CONFIGURATION, EPHEMERAL_ENV } from 'src/configuration';
+import { CONTAINERIZED_DEPLOYMENT_DETAILS, DEPLOYMENT_DETAILS, DIRECTORY_CONFIGURATION, EPHEMERAL_ENV, MESSAGE } from 'src/configuration';
 import { LoggerService } from 'src/configuration/logger/logger.service';
 import {
   ApplicationConfigDTO,
@@ -807,5 +807,14 @@ export class ApplicationFactory {
     // @internal if CMDB code is not present we'll send the SPAS-001 as the default CMDB code
     if (cmdbCode === 'NA') return 'SPAS-001';
     return cmdbCode;
+  }
+
+  validateEphemeralRequestForDuration(applicationDto: CreateApplicationDto) {
+    const expiresIn = Number(applicationDto?.expiresIn);
+    const maxDuration = Number(EPHEMERAL_ENV.maximumDuration);
+    const isEphemeralWithCustomDuration = applicationDto.ephemeral && expiresIn;
+    if (isEphemeralWithCustomDuration && (expiresIn < 1 || expiresIn > maxDuration)) {
+      this.exceptionService.badRequestException({ message: MESSAGE.INVALID_EPHEXPIRESIN });
+    }
   }
 }

--- a/packages/api/src/server/application/service/application.factory.ts
+++ b/packages/api/src/server/application/service/application.factory.ts
@@ -76,7 +76,7 @@ export class ApplicationFactory {
       websiteName: propertyIdentifier,
       name,
       mapping: appPath,
-      cmdbCode,
+      cmdbCode: this.getCMDBCode(cmdbCode),
       environments: [{ name: env, updateRestriction: false, exclude: false, ns: namespace }]
     };
     this.logger.log('SpashipFile', JSON.stringify(spashipFile));
@@ -780,7 +780,7 @@ export class ApplicationFactory {
       websiteName: property.identifier,
       name: application.identifier,
       mapping: application.path,
-      cmdbCode: property.cmdbCode,
+      cmdbCode: this.getCMDBCode(property.cmdbCode),
       environments: [{ name: application.env, updateRestriction: false, exclude: true, ns: property.namespace }]
     };
     this.logger.log('SpashipFile', JSON.stringify(spashipFile));
@@ -801,5 +801,11 @@ export class ApplicationFactory {
       this.exceptionService.internalServerErrorException(err);
     }
     return zipPath;
+  }
+
+  private getCMDBCode(cmdbCode: string) {
+    // @internal if CMDB code is not present we'll send the SPAS-001 as the default CMDB code
+    if (cmdbCode === 'NA') return 'SPAS-001';
+    return cmdbCode;
   }
 }

--- a/packages/api/src/server/application/service/application.module.ts
+++ b/packages/api/src/server/application/service/application.module.ts
@@ -11,6 +11,8 @@ import { PermissionFactory } from 'src/server/permission/service/permission.fact
 import { PermissionService } from 'src/server/permission/service/permission.service';
 import { PropertyFactory } from 'src/server/property/service/property.factory';
 import { PropertyService } from 'src/server/property/service/property.service';
+import { CMDBFactory } from 'src/server/sot/cmdb/service/cmdb.factory';
+import { CMDBService } from 'src/server/sot/cmdb/service/cmdb.service';
 import { DataServicesModule } from '../../../repository/data-services.module';
 import { ApplicationFactory } from './application.factory';
 import { ApplicationService } from './application.service';
@@ -30,7 +32,9 @@ import { ApplicationService } from './application.service';
     PropertyFactory,
     PropertyService,
     PermissionService,
-    PermissionFactory
+    PermissionFactory,
+    CMDBService,
+    CMDBFactory
   ],
   exports: [ApplicationFactory, ApplicationService]
 })

--- a/packages/api/src/server/environment/service/environment.module.ts
+++ b/packages/api/src/server/environment/service/environment.module.ts
@@ -11,6 +11,8 @@ import { PermissionFactory } from 'src/server/permission/service/permission.fact
 import { PermissionService } from 'src/server/permission/service/permission.service';
 import { PropertyFactory } from 'src/server/property/service/property.factory';
 import { PropertyService } from 'src/server/property/service/property.service';
+import { CMDBFactory } from 'src/server/sot/cmdb/service/cmdb.factory';
+import { CMDBService } from 'src/server/sot/cmdb/service/cmdb.service';
 import { DataServicesModule } from '../../../repository/data-services.module';
 import { EnvironmentFactory } from './environment.factory';
 import { EnvironmentService } from './environment.service';
@@ -30,7 +32,9 @@ import { EnvironmentService } from './environment.service';
     AgendaService,
     LoggerService,
     PermissionService,
-    PermissionFactory
+    PermissionFactory,
+    CMDBService,
+    CMDBFactory
   ],
   exports: [EnvironmentFactory, EnvironmentService]
 })

--- a/packages/api/src/server/property/service/property.module.ts
+++ b/packages/api/src/server/property/service/property.module.ts
@@ -11,6 +11,8 @@ import { EnvironmentService } from 'src/server/environment/service/environment.s
 import { ExceptionsService } from 'src/server/exceptions/exceptions.service';
 import { PermissionFactory } from 'src/server/permission/service/permission.factory';
 import { PermissionService } from 'src/server/permission/service/permission.service';
+import { CMDBFactory } from 'src/server/sot/cmdb/service/cmdb.factory';
+import { CMDBService } from 'src/server/sot/cmdb/service/cmdb.service';
 import { DataServicesModule } from '../../../repository/data-services.module';
 import { PropertyFactory } from './property.factory';
 import { PropertyService } from './property.service';
@@ -30,7 +32,9 @@ import { PropertyService } from './property.service';
     AgendaService,
     LoggerService,
     PermissionService,
-    PermissionFactory
+    PermissionFactory,
+    CMDBService,
+    CMDBFactory
   ],
   exports: [PropertyFactory, PropertyService]
 })

--- a/packages/api/src/server/property/service/property.service.ts
+++ b/packages/api/src/server/property/service/property.service.ts
@@ -70,7 +70,7 @@ export class PropertyService {
       identifier: createPropertyDto.identifier
     });
     if (checkProperty.length > 0) this.exceptionService.badRequestException({ message: 'Property already exist.' });
-    if (createPropertyDto.cmdbCode && createPropertyDto.cmdbCode !== 'NA') {
+    if (createPropertyDto?.cmdbCode && createPropertyDto?.cmdbCode !== 'NA') {
       const validateCMDB = await this.cmdbService.getCMDBDetailsByCode(createPropertyDto.cmdbCode);
       if (!validateCMDB.length) this.exceptionService.badRequestException({ message: 'CMDB code is not valid.' });
     }
@@ -120,7 +120,7 @@ export class PropertyService {
       })
     )[0];
     if (!propertyDetails) this.exceptionService.badRequestException({ message: 'No Property Found.' });
-    if (createPropertyDto.cmdbCode && createPropertyDto.cmdbCode !== 'NA') {
+    if (createPropertyDto?.cmdbCode && createPropertyDto?.cmdbCode !== 'NA') {
       const validateCMDB = await this.cmdbService.getCMDBDetailsByCode(createPropertyDto.cmdbCode);
       if (!validateCMDB.length) this.exceptionService.badRequestException({ message: 'CMDB code is not valid.' });
     }


### PR DESCRIPTION
Subject:  chore(api) : cmdb code validation & default code process, eph env duration limit
Assignees: @soumyadip007 

## Closes / Fixes 

1. Set CMDB default code as SPAS-001 if cmdb code is note preset
2. Check CMDB code every time before creating a property 
3. Maximum duration for Eph Env set to 500 hrs

## Does this PR introduce a breaking change

NO

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->

## Screenshot(s)

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

<!-- Add your screenshot(s) below this line -->

</details>

### Ready-for-merge Checklist

- [ ] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Does the change have appropriate unit tests?
- [ ] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [ ] Was this feature demo'd and the design review approved?
