### PR TITLE
feat(manager) : EmptyInfo apikey link fix

### DIFF
--- a/packages/manager/src/views/Settings/Settings.tsx
+++ b/packages/manager/src/views/Settings/Settings.tsx
@@ -11,8 +11,6 @@ import { Environment } from '@app/views/Settings/components/Environment';
 import { Symlink } from './components/Symlink';
 
 export const Settings: React.FunctionComponent = () => {
-  const [activeTabKey, setActiveTabKey] = useState<string | number>(0);
-
   const handleTabClick = (
     event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent,
     tabIndex: string | number
@@ -21,7 +19,8 @@ export const Settings: React.FunctionComponent = () => {
   };
   const { query } = useRouter();
   const propertyIdentifier = query.propertyIdentifier as string;
-
+  const initialActiveTabKey = query.activeTabKey ? parseInt(query.activeTabKey as string) : 0;
+  const [activeTabKey, setActiveTabKey] = useState<string | number>(initialActiveTabKey);
   const envList = useGetEnvList(propertyIdentifier);
 
   return (

--- a/packages/manager/src/views/WebPropertyDetailPage/components/EmptyInfo/EmptyInfo.tsx
+++ b/packages/manager/src/views/WebPropertyDetailPage/components/EmptyInfo/EmptyInfo.tsx
@@ -58,11 +58,11 @@ export const EmptyInfo = ({ propertyIdentifier }: Props): JSX.Element => (
           <Link
             href={{
               pathname: pageLinks.webPropertySettingPage,
-              query: { propertyIdentifier }
+              query: { propertyIdentifier, activeTabKey: 2 }
             }}
           >
             <a>
-              <Text>(Environment Configuration)</Text>
+              <Text>(API Key Configuration)</Text>
             </a>
           </Link>
         </ListItem>


### PR DESCRIPTION
## Closes / Fixes / Resolves
Closes #issue_id
## Explain the feature/fix

<!-- Provide a clear explaination of the feature/fix implemented -->
- Initially, the 'Generate API Key' link directed users to the 'Environment' tab in Settings.
- corrected the link to guide users to the specific tab relevant to API key configuration in the Settings.
- The link was originally labeled as 'Environment Configuration.'
- We have updated the label to 'API Key Configuration' for improved clarity.

## Does this PR introduce a breaking change

<!-- Yes/No -->

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
No
## Screenshot(s)

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

<!-- Add your screenshot(s) below this line -->
![Screenshot from 2024-01-09 11-27-37](https://github.com/spaship/spaship/assets/39623025/8e223444-294d-4136-bfb2-b7f300b4f848)
![Screenshot from 2024-01-09 11-27-51](https://github.com/spaship/spaship/assets/39623025/dc2e575c-d2f3-4680-b7a3-3bec525657ae)

</details>
