### PR TITLE
fix(api) : get single response for the lighthouse report

### DIFF
--- a/packages/api/src/server/lighthouse/service/factory.ts
+++ b/packages/api/src/server/lighthouse/service/factory.ts
@@ -63,7 +63,9 @@ export class LighthouseFactory {
     if (!buildId) this.exceptionService.badRequestException({ message: 'Please provide the buildId' });
     let response;
     try {
-      response = await this.httpService.axiosRef.get(`${LIGHTHOUSE_DETAILS.hostUrl}/v1/projects/${projectId}/builds/${buildId}/runs`);
+      response = await this.httpService.axiosRef.get(
+        `${LIGHTHOUSE_DETAILS.hostUrl}/v1/projects/${projectId}/builds/${buildId}/runs?representative=true`
+      );
     } catch (err) {
       this.logger.error('getLighthouseReportDetails', err);
       this.exceptionService.badRequestException({ message: `Error in fetching report Failed.` });

--- a/packages/api/src/server/lighthouse/service/index.ts
+++ b/packages/api/src/server/lighthouse/service/index.ts
@@ -154,7 +154,7 @@ export class LighthouseService {
     isContainerized: boolean = false,
     isGit: boolean = false
   ): Promise<LighthouseResponseDTO[]> {
-    const toBeSkipped = 'buildId';
+    const toBeSkipped = 'lhBuildId';
     const propertyDetails = (await this.dataServices.property.getByAny({ identifier: propertyIdentifier }))[0];
     if (!propertyDetails) this.exceptionService.badRequestException({ message: 'No Property Found.' });
     if (!propertyDetails.lighthouseDetails)


### PR DESCRIPTION
Subject:  fix(api) : get single response for the lighthouse report
Assignees: @soumyadip007 

## Closes / Fixes

1. Get single response for the lighthouse report
2. lhBuildId replaced buildId added to the skip specfier

## Does this PR introduce a breaking change

NO

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->

## Screenshot(s)

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

<!-- Add your screenshot(s) below this line -->

</details>

### Ready-for-merge Checklist

- [ ] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Does the change have appropriate unit tests?
- [ ] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [ ] Was this feature demo'd and the design review approved?
