### PR TITLE
feat(Manager): Fixed issue of first of data for SPA detailed and lighthouse page | Application status bug resolved

### DIFF
--- a/packages/manager/src/services/lighthouse/queries.tsx
+++ b/packages/manager/src/services/lighthouse/queries.tsx
@@ -14,10 +14,10 @@ const fetchLighthouseReportForGivenBuildId = async (
   propertyIdentifier: string,
   identifier: string,
   env: string,
-  buildId: string
+  selected: string
 ): Promise<any> => {
   const { data } = await orchestratorReq.get(
-    `/lighthouse/${propertyIdentifier}/${env}/lighthouse/${buildId}`,
+    `/lighthouse/${propertyIdentifier}/${env}/lighthouse/${selected}`,
     {
       params: {
         skip: 'lhBuildId'
@@ -25,17 +25,22 @@ const fetchLighthouseReportForGivenBuildId = async (
     }
   );
 
-  return data.data[0] || [];
+  return data?.data[0] || {}; // Handle potential undefined data
 };
 
 export const useLighthouseReportForGivenBuildId = (
   webPropertyIdentifier: string,
   identifier: string,
   env: string,
-  buildId: string
+  selected: string
 ) =>
-  useQuery(lighthouseKeys.list(webPropertyIdentifier, env), () =>
-    fetchLighthouseReportForGivenBuildId(webPropertyIdentifier, identifier, env, buildId)
+  useQuery(
+    [lighthouseKeys.list(webPropertyIdentifier, env), selected], // Combine keys for uniqueness
+    () => fetchLighthouseReportForGivenBuildId(webPropertyIdentifier, identifier, env, selected),
+    {
+      enabled: selected !== 'Select build-id', // Disable query for "Select build-id"
+      staleTime: Infinity // Prevent automatic refetching
+    }
   );
 
 const fetchLhIdentifierList = async (

--- a/packages/manager/src/services/spaProperty/queries.tsx
+++ b/packages/manager/src/services/spaProperty/queries.tsx
@@ -62,4 +62,4 @@ const fetchStatusForAnApplication = async (link: string): Promise<boolean> => {
 };
 
 export const useGetStatusForAnApplication = (link: string, _id: string) =>
-  useQuery([`${_id}`], () => fetchStatusForAnApplication(link));
+  useQuery([`${link}_${_id}`], () => fetchStatusForAnApplication(link));

--- a/packages/manager/src/views/SPAPropertyDetailPage/ContainerizedSPADeployment/ContainerizedSPADeployment.tsx
+++ b/packages/manager/src/views/SPAPropertyDetailPage/ContainerizedSPADeployment/ContainerizedSPADeployment.tsx
@@ -45,7 +45,7 @@ import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { AxiosError } from 'axios';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
 import { ApplicationStatus } from '../../WebPropertyDetailPage/components/SSR/ApplicationStatus';
 import { ConfigureSSRForm } from '../../WebPropertyDetailPage/components/SSR/ConfigureSSRForm';
@@ -399,7 +399,12 @@ export const ContainerizedSPADeployment = (): JSX.Element => {
       })}
     </DataList>
   );
-
+  useEffect(() => {
+    if (!selectedData) {
+      setSelectedData(containerizedDeploymentData?.[0]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [containerizedDeploymentData]);
   return (
     <div>
       <Button

--- a/packages/manager/src/views/SPAPropertyDetailPage/StaticSPADeployment.tsx/StaticSPADeployment.tsx
+++ b/packages/manager/src/views/SPAPropertyDetailPage/StaticSPADeployment.tsx/StaticSPADeployment.tsx
@@ -32,7 +32,7 @@ import {
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { AxiosError } from 'axios';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
 import { useGetWebPropertyGroupedByEnv } from '@app/services/persistent';
 import { TSpaProperty } from '@app/services/spaProperty/types';
@@ -314,7 +314,12 @@ export const StaticSPADeployment = (): JSX.Element => {
       })}
     </DataList>
   );
-
+  useEffect(() => {
+    if (!selectedData) {
+      setSelectedData(staticDeploymentData?.[0]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [staticDeploymentData]);
   return (
     <div>
       {!staticDeploymentData?.length ? (

--- a/packages/manager/src/views/SPAPropertyDetailPage/StaticSPADeployment.tsx/StaticSPADeployment.tsx
+++ b/packages/manager/src/views/SPAPropertyDetailPage/StaticSPADeployment.tsx/StaticSPADeployment.tsx
@@ -41,7 +41,7 @@ import { CubesIcon, SyncAltIcon } from '@patternfly/react-icons';
 import { ApplicationStatus } from '../../WebPropertyDetailPage/components/SSR/ApplicationStatus';
 import { Lighthouse } from '../Lighthouse/Lighthouse';
 
-const INTERNAL_ACCESS_URL_LENGTH = 40;
+const INTERNAL_URL_LENGTH = 40;
 
 export const StaticSPADeployment = (): JSX.Element => {
   const { query } = useRouter();
@@ -177,8 +177,8 @@ export const StaticSPADeployment = (): JSX.Element => {
                           rel="noopener noreferrer"
                           style={{ textDecoration: 'none', marginRight: '8px' }}
                         >
-                          {`${url.slice(0, INTERNAL_ACCESS_URL_LENGTH)} ${
-                            url.length > INTERNAL_ACCESS_URL_LENGTH ? '...' : ''
+                          {`${url.slice(0, INTERNAL_URL_LENGTH)} ${
+                            url.length > INTERNAL_URL_LENGTH ? '...' : ''
                           }`}
                         </a>
                       </Tooltip>{' '}
@@ -231,8 +231,8 @@ export const StaticSPADeployment = (): JSX.Element => {
                           rel="noopener noreferrer"
                           style={{ textDecoration: 'none', marginRight: '8px' }}
                         >
-                          {`${url.slice(0, INTERNAL_ACCESS_URL_LENGTH)} ${
-                            url.length > INTERNAL_ACCESS_URL_LENGTH ? '...' : ''
+                          {`${url.slice(0, INTERNAL_URL_LENGTH)} ${
+                            url.length > INTERNAL_URL_LENGTH ? '...' : ''
                           }`}
                         </a>
                       </Tooltip>{' '}

--- a/packages/manager/src/views/WebPropertyDetailPage/components/SSR/ApplicationStatus.tsx
+++ b/packages/manager/src/views/WebPropertyDetailPage/components/SSR/ApplicationStatus.tsx
@@ -4,7 +4,6 @@ import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons'
 
 export const ApplicationStatus = ({ link, _id }: { link: string; _id: string }) => {
   const { data } = useGetStatusForAnApplication(link, _id);
-  console.log('data status', _id);
   return (
     <div style={{ display: 'inline' }}>
       {data ? (


### PR DESCRIPTION
<!--
Follow the steps to create the PR:

Subject: "feat/fix/docs(#issue_id): <PR Subject>"
Assignees: "Developers"
Projects: ""
-->

## Closes / Fixes / Resolves

<!-- Comman separated list of GitHub Issue ID(s) -->

## Explain the feature/fix

1. First load of data in spa detailed page was not coming for both static and containerized builds
2. Fixing application down status for both access and router urls

<!-- Provide a clear explaination of the feature/fix implemented -->

## Does this PR introduce a breaking change

<!-- Yes/No -->

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->

## Screenshot(s)

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

<!-- Add your screenshot(s) below this line -->

</details>

### Ready-for-merge Checklist

- [ ] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Does the change have appropriate unit tests?
- [ ] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [ ] Was this feature demo'd and the design review approved?
