### PR TITLE
chore(api) : buildDir arg & flag issues resolved, validation added, version updated

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spaship/cli",
   "description": "A command line interface for SPAship!",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "author": "mclayton@redhat.com",
   "bin": {
     "spaship": "./bin/run"

--- a/packages/cli/src/commands/deploy.js
+++ b/packages/cli/src/commands/deploy.js
@@ -31,15 +31,20 @@ class DeployCommand extends Command {
     const { args, flags } = this.parse(DeployCommand);
 
     const config = loadRcFile();
-    const yamlConfig = await common.config.read("spaship.yaml");
+    let yamlConfig;
+    try{
+      yamlConfig= await common.config.read("spaship.yaml");
+    } catch(e) {
+      this.error("Please run spaship init to generate spaship.yaml.");
+    }
     const yamlPath = yamlConfig && yamlConfig.path;
     // We need send `name` and `path` to API
     // so read them from spaship.yaml or other config file
     // it could be store in package.json
     const name = yamlConfig ? yamlConfig.name : config.name;
     let path = flags.path || yamlPath;
-    const configBuildDir = yamlConfig ? yamlConfig.buildDir : config.buildDir; // buildDIr from config
-    const buildDir = flags.builddir ? flags.builddir : configBuildDir; // uses command line arg if present
+    const configBuildDir = yamlConfig ? (yamlConfig.buildDir || yamlConfig.builddir) : (config.buildDir || config.builddir); // buildDIr from config
+    const buildDir = (flags.builddir || flags.buildDir) ? (flags.builddir || flags.buildDir) : configBuildDir; // uses command line arg if present
     const ephemeral = flags?.preview || false;
     const actionId = flags?.prid;
     const duration = flags?.duration;
@@ -162,7 +167,7 @@ class DeployCommand extends Command {
           if (actionId) {
             data.append("actionId", actionId);
           }
-          if(duration){
+          if (duration) {
             data.append("expiresIn", duration);
           }
         }
@@ -262,6 +267,12 @@ DeployCommand.flags = assign(
   {
     builddir: flags.string({
       char: "b",
+      required: false,
+      description: "path of your SPAs artifact. Defaults to 'buildDir' if specified in the spaship.yaml.",
+    }),
+  },
+  {
+    buildDir: flags.string({
       required: false,
       description: "path of your SPAs artifact. Defaults to 'buildDir' if specified in the spaship.yaml.",
     }),

--- a/packages/cli/src/common/config/validate.js
+++ b/packages/cli/src/common/config/validate.js
@@ -32,6 +32,10 @@ const schema = {
       description: "a directory to package and deploy (can be used instead of uploading a zip file)",
       type: "string",
     },
+    builddir: {
+      description: "a directory to package and deploy (can be used instead of uploading a zip file)",
+      type: "string",
+    },
   },
   required: ["path", "name"],
 };


### PR DESCRIPTION
Subject: chore(api) : buildDir arg, validation added 
Assignees: @soumyadip007 

## Closes / Fixes

1.  Spaship init without overwrite flag- misleading info being provided
2. when using spaship init, from a ci perspective, able to generate spaship.yaml without providing name 
3. spaship init --builddir command creates incorrect key in spaship.yaml
4. Fix the msg ENOENT: no such file or directory, open 'spaship.yaml' Code: ENOENT
5. version bump to 1.7.0


## Does this PR introduce a breaking change

NO

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->

## Screenshot(s)

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

<!-- Add your screenshot(s) below this line -->

</details>

### Ready-for-merge Checklist

- [ ] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Does the change have appropriate unit tests?
- [ ] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [ ] Was this feature demo'd and the design review approved?
