### PR TITLE
feat: Add optional tagsuffix and ugroup inputs to GitHub Action for orchestrator

### DIFF
--- a/.github/workflows/api-ci.yaml
+++ b/.github/workflows/api-ci.yaml
@@ -10,10 +10,12 @@ on:
       - '*'
   workflow_dispatch:
     inputs:
-      version:
-        description: Bump Version
-        default: v1.0.0
-        required: true
+      tagsuffix:
+        description: Tag suffix for the image
+        required: false
+      ugroup:
+        description: Docker User Group[keep it set to the default if you are unsure]
+        required: false
 jobs:
   push_to_registry:
     name: Push Docker image to Registries
@@ -35,6 +37,24 @@ jobs:
           username: ${{ secrets.CI_QUAY_USERNAME }}
           password: ${{ secrets.CI_QUAY_TOKEN }}
 
+      - name: Set tag suffix
+        id: set_tag_suffix
+        run: |
+          if [[ -z "${{ github.event.inputs.tagsuffix }}" ]]; then
+            echo "TAG_SUFFIX=" >> $GITHUB_ENV
+          else
+            echo "TAG_SUFFIX=-${{ github.event.inputs.tagsuffix }}" >> $GITHUB_ENV
+          fi
+
+      - name: Set docker user group
+        id: set_docker_user_group
+        run: |
+          if [[ -z "${{ github.event.inputs.ugroup }}" ]]; then
+            echo "USERGROUP=1002590000" >> $GITHUB_ENV
+          else
+            echo "USERGROUP=${{ github.event.inputs.ugroup }}" >> $GITHUB_ENV
+          fi
+
       - name: Build and push into repository
         id: docker_build
         uses: docker/build-push-action@v2
@@ -42,7 +62,9 @@ jobs:
           context: ./packages/api
           file: ./packages/api/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
+          build-args: |
+            USERGROUP=${{ env.USERGROUP }}
           tags: |
-            quay.io/${{ env.REGISTRY_NAMESPACE }}/${{ env.IMAGE_NAME }}:${{env.GITHUB_REF_SLUG}}
+            quay.io/${{ env.REGISTRY_NAMESPACE }}/${{ env.IMAGE_NAME }}:${{env.GITHUB_REF_SLUG}}${{ env.TAG_SUFFIX }}
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -1,16 +1,18 @@
 FROM node:18-alpine3.16
 
-RUN addgroup allusers && adduser -S -G allusers 1002590000
+ARG USERGROUP
+RUN echo "USERGROUP: $USERGROUP"
+RUN addgroup allusers && adduser -S -G allusers $USERGROUP
 RUN mkdir /.npm
 WORKDIR /app
 COPY . .
 RUN mkdir spaship_uploads && mkdir root
 RUN npm install
 RUN npm run build
-RUN chown -R 1002590000:allusers .
-RUN chown -R 1002590000:allusers ~/.npm
-RUN chown -R 1002590000:allusers /.npm
+RUN chown -R $USERGROUP:allusers .
+RUN chown -R $USERGROUP:allusers ~/.npm
+RUN chown -R $USERGROUP:allusers /.npm
 RUN chmod -R 777 .
 EXPOSE 2345
-USER 1002590000
+USER $USERGROUP
 CMD [ "npm", "run", "start:prod"]


### PR DESCRIPTION
Introduced optional `tagsuffix` and `ugroup` inputs to the API GitHub Action. The `tagsuffix` is appended to the image tag if set, enhancing versioning flexibility. The `ugroup` input serves as a build argument for specifying a user group in the Dockerfile, with a provision to leave it blank for default assignment. This update addresses environment-specific user range discrepancies, offering a more adaptable build configuration.

<!--
Follow the steps to create the PR:

Subject: "feat/fix/docs(#issue_id): <PR Subject>"
Assignees: "Developers"
Projects: ""
-->

## Closes / Fixes / Resolves

Manual changes in docker file every time


## Does this PR introduce a breaking change
No
