### PR TITLE
feat(router): add GitHub Action for building and pushing SPAship router image

### DIFF
--- a/.github/workflows/router.yaml
+++ b/.github/workflows/router.yaml
@@ -1,0 +1,72 @@
+name: SPAship router build and push into container repo
+
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - '*'
+    paths:
+      - '*'
+  workflow_dispatch:
+    inputs:
+      tagsuffix:
+        description: Tag suffix for the image
+        required: false
+      ugroup:
+        description: Docker User Group[keep it set to the default if you are unsure]
+        required: false
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Registries
+    env:
+      IMAGE_NAME: "router"
+      REGISTRY_NAMESPACE: "spaship"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v3.x
+
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.CI_QUAY_USERNAME }}
+          password: ${{ secrets.CI_QUAY_TOKEN }}
+
+      - name: Set tag suffix
+        id: set_tag_suffix
+        run: |
+          if [[ -z "${{ github.event.inputs.tagsuffix }}" ]]; then
+            echo "TAG_SUFFIX=" >> $GITHUB_ENV
+          else
+            echo "TAG_SUFFIX=-${{ github.event.inputs.tagsuffix }}" >> $GITHUB_ENV
+          fi
+
+      - name: Set docker user group
+        id: set_docker_user_group
+        run: |
+          if [[ -z "${{ github.event.inputs.ugroup }}" ]]; then
+            echo "USERGROUP=1002590000" >> $GITHUB_ENV
+          else
+            echo "USERGROUP=${{ github.event.inputs.ugroup }}" >> $GITHUB_ENV
+          fi
+
+      - name: Build and push into repository
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./ContainerFile-router
+          push: ${{ github.event_name != 'pull_request' }}
+          build-args: |
+            USERGROUP=${{ env.USERGROUP }}
+          tags: |
+            quay.io/${{ env.REGISTRY_NAMESPACE }}/${{ env.IMAGE_NAME }}:${{env.GITHUB_REF_SLUG}}${{ env.TAG_SUFFIX }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/router.yaml
+++ b/.github/workflows/router.yaml
@@ -38,6 +38,13 @@ jobs:
           username: ${{ secrets.CI_QUAY_USERNAME }}
           password: ${{ secrets.CI_QUAY_TOKEN }}
 
+      - name: Login to Red Hat Registry
+        uses: docker/login-action@v1
+        with:
+          registry: registry.redhat.io
+          username: ${{ secrets.REDHAT_REGISTRY_USERNAME }}
+          password: ${{ secrets.REDHAT_REGISTRY_TOKEN }}
+
       - name: Set tag suffix
         id: set_tag_suffix
         run: |

--- a/ContainerFile-router
+++ b/ContainerFile-router
@@ -1,29 +1,36 @@
 FROM registry.redhat.io/rhel9/nodejs-20-minimal as build
-WORKDIR /usr/src/spaship
 
-COPY lerna.json ./
-COPY package.json ./
-COPY packages ./packages
+USER 1001
+
+WORKDIR /opt/app-root/src/spaship
+
+COPY --chown=1001:0 lerna.json ./
+COPY --chown=1001:0 package.json ./
+COPY --chown=1001:0 packages ./packages
+COPY --chown=1001:0 package-lock.json ./
+
 
 RUN cd packages/common && \
     npm install && \
     npm link && \
     cd ../router && \
     npm link @spaship/common && \
-    rm -rf /root/.npm
+    rm -rf /opt/app-root/src/.npm
 
 
-WORKDIR /usr/src/spaship/packages/router
+WORKDIR /opt/app-root/src/spaship/packages/router
 
 
 FROM registry.redhat.io/rhel9/nodejs-20-minimal
 
-WORKDIR /usr/src/spaship/packages
+USER 1001
 
-COPY --from=build /usr/src/spaship/packages/common ./common
-COPY --from=build /usr/src/spaship/packages/router ./router
+WORKDIR /opt/app-root/src/spaship/packages
 
-WORKDIR /usr/src/spaship/packages/router
+COPY --from=build /opt/app-root/src/spaship/packages/common ./common
+COPY --from=build /opt/app-root/src/spaship/packages/router ./router
+
+WORKDIR /opt/app-root/src/spaship/packages/router
 
 EXPOSE 8765
 

--- a/ContainerFile-router
+++ b/ContainerFile-router
@@ -1,4 +1,4 @@
-FROM node:22-alpine as build
+FROM registry.redhat.io/rhel9/nodejs-20-minimal as build
 WORKDIR /usr/src/spaship
 
 COPY lerna.json ./
@@ -16,7 +16,7 @@ RUN cd packages/common && \
 WORKDIR /usr/src/spaship/packages/router
 
 
-FROM node:22-alpine
+FROM registry.redhat.io/rhel9/nodejs-20-minimal
 
 WORKDIR /usr/src/spaship/packages
 


### PR DESCRIPTION
## Description
This PR introduces a new GitHub Action workflow to automate the building and pushing of the SPAship router container image to our Quay.io registry. This action parallels our existing workflow for the SPAship api service.

## Changes Made
- Created a new workflow file: `.github/workflows/router-build-push.yml`
- Configured the action to use the `ContainerFile-router` for building the image
- Set up authentication and pushing to Quay.io registry
- Implemented dynamic tagging based on git refs and optional inputs
- Enabled manual triggering with customizable options

## Additional Notes
- This action assumes `ContainerFile-router` is in the root directory of the repository
- The workflow uses the same secret management as the existing API workflow

