### PR TITLE
chore(api) : override files during extracting and zipping applications

### DIFF
--- a/packages/api/src/server/application/service/index.ts
+++ b/packages/api/src/server/application/service/index.ts
@@ -305,7 +305,7 @@ export class ApplicationService {
     const { baseDir } = DIRECTORY_CONFIGURATION;
     let tmpDir = `${baseDir}/${identifier.split('.')[0]}-${Date.now()}-extracted`;
     await fs.mkdirSync(`${tmpDir}`, { recursive: true });
-    const unzipCommand = `7z x ${path.resolve(applicationPath)} -o${tmpDir}`;
+    const unzipCommand = `7z x ${path.resolve(applicationPath)} -o${tmpDir} -aoa`;
     const execPromise = await util.promisify(exec);
     try {
       await execPromise(unzipCommand);
@@ -315,7 +315,7 @@ export class ApplicationService {
        */
       if (fileOrginalName.endsWith('tar.gz') || fileOrginalName.endsWith('tgz')) {
         const nestedOutputDirectory = `${baseDir}/${identifier.split('.')[0]}-${Date.now()}-extracted`;
-        const nestedUnzipCommand = `7z x ${path.resolve(tmpDir)}/*.tar -o${nestedOutputDirectory}`;
+        const nestedUnzipCommand = `7z x ${path.resolve(tmpDir)}/*.tar -o${nestedOutputDirectory} -aoa`;
         try {
           await execPromise(nestedUnzipCommand);
           tmpDir = nestedOutputDirectory;


### PR DESCRIPTION
Subject: override files during extracting and zipping applications
Assignees: @soumyadip007

## Closes / Fixes

1. This PR introduces commands to ensure files are overwritten during the extraction process using 7-Zip. The commands use the `-aoa` (Overwrite All) option to automatically overwrite existing files without prompting.

## Does this PR introduce a breaking change

NO

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->

## Screenshot(s)

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

<!-- Add your screenshot(s) below this line -->

</details>

### Ready-for-merge Checklist

- [ ] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Does the change have appropriate unit tests?
- [ ] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [ ] Was this feature demo'd and the design review approved?