### PR TITLE
chore(api) : version updated for the api packages

### DIFF
--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spaship-api",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "spaship-api",
-      "version": "4.7.0",
+      "version": "4.7.1",
       "dependencies": {
         "@nestjs/axios": "^3.0.0",
         "@nestjs/common": "^9.1.6",
@@ -35,7 +35,7 @@
         "fs": "0.0.1-security",
         "js-base64": "^3.7.5",
         "jwt-decode": "^3.1.2",
-        "mongoose": "^7.5.1",
+        "mongoose": "^7.8.4",
         "mongoose-autopopulate": "^1.0.1",
         "multer": "^1.4.5-lts.1",
         "reflect-metadata": "^0.1.13",
@@ -6973,11 +6973,6 @@
         "ms": "2.0.0"
       }
     },
-    "node_modules/eventstore/node_modules/lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
-    },
     "node_modules/eventstore/node_modules/uuid": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
@@ -7365,10 +7360,11 @@
       "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
     },
     "node_modules/flatted": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -9452,9 +9448,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
@@ -9871,13 +9868,14 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.5.1.tgz",
-      "integrity": "sha512-gJCkUtW3KgAu7Uf8HTVv+S3wf9+xldR5LFYM6mABJJQHQB0aWUGyC3bWsl2X/6dVHZSoQq3wh5UV7rWC4FrewA==",
+      "version": "7.8.9",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.8.9.tgz",
+      "integrity": "sha512-V3GBAJbmOAdzEP8murOvlg7q1szlbe4jTBRyW+JBHRduJBe7F9dk5eyqJDTuYrdBcOOWfLbr6AgXrDK7F0/o5A==",
+      "license": "MIT",
       "dependencies": {
-        "bson": "^5.4.0",
+        "bson": "^5.5.0",
         "kareem": "2.5.1",
-        "mongodb": "5.8.1",
+        "mongodb": "5.9.2",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",
@@ -9900,19 +9898,21 @@
       }
     },
     "node_modules/mongoose/node_modules/bson": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.4.0.tgz",
-      "integrity": "sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
+      "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=14.20.1"
       }
     },
     "node_modules/mongoose/node_modules/mongodb": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.8.1.tgz",
-      "integrity": "sha512-wKyh4kZvm6NrCPH8AxyzXm3JBoEf4Xulo0aUWh3hCgwgYJxyQ1KLST86ZZaSWdj6/kxYUA3+YZuyADCE61CMSg==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
+      "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "bson": "^5.4.0",
+        "bson": "^5.5.0",
         "mongodb-connection-string-url": "^2.6.0",
         "socks": "^2.7.1"
       },
@@ -12932,7 +12932,7 @@
             "cli-width": "^3.0.0",
             "external-editor": "^3.0.3",
             "figures": "^3.0.0",
-            "lodash": "^4.17.21",
+            "lodash": "^4.18.1",
             "mute-stream": "0.0.8",
             "ora": "^5.4.1",
             "run-async": "^2.4.0",
@@ -14940,7 +14940,7 @@
       "requires": {
         "dotenv": "16.0.1",
         "dotenv-expand": "8.0.3",
-        "lodash": "4.17.21",
+        "lodash": "^4.18.1",
         "uuid": "8.3.2"
       },
       "dependencies": {
@@ -14982,7 +14982,7 @@
           "dev": true,
           "requires": {
             "jws": "^3.2.2",
-            "lodash": "^4.17.21",
+            "lodash": "^4.18.1",
             "ms": "^2.1.1",
             "semver": "^7.3.8"
           }
@@ -15138,7 +15138,7 @@
       "requires": {
         "@nestjs/mapped-types": "1.2.0",
         "js-yaml": "4.1.0",
-        "lodash": "4.17.21",
+        "lodash": "^4.18.1",
         "path-to-regexp": "3.2.0",
         "swagger-ui-dist": "4.15.1"
       }
@@ -15235,7 +15235,7 @@
         "ajv": "^6.10.2",
         "express-pino-logger": "^5.0.0",
         "js-yaml": "^3.13.1",
-        "lodash": "^4.17.15",
+        "lodash": "^4.18.1",
         "nconf": "^0.11.0",
         "pino": "^6.0.0"
       },
@@ -18038,7 +18038,7 @@
         "debug": "3.1.0",
         "dotty": "0.0.2",
         "jsondate": "0.0.1",
-        "lodash": "4.17.19",
+        "lodash": "^4.18.1",
         "parent-require": "1.0.0",
         "tolerance": "1.0.0",
         "uuid": "3.3.3"
@@ -18049,7 +18049,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
           "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
           "requires": {
-            "lodash": "^4.17.11"
+            "lodash": "^4.18.1"
           }
         },
         "debug": {
@@ -18059,11 +18059,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.19",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
         },
         "uuid": {
           "version": "3.3.3",
@@ -18361,7 +18356,7 @@
       "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
       "dev": true,
       "requires": {
-        "flatted": "^3.1.0",
+        "flatted": "^3.4.2",
         "rimraf": "^3.0.2"
       }
     },
@@ -18371,9 +18366,9 @@
       "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
     },
     "flatted": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
     },
     "follow-redirects": {
@@ -18790,7 +18785,7 @@
         "cli-width": "^3.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "mute-stream": "0.0.8",
         "ora": "^5.4.1",
         "run-async": "^2.4.0",
@@ -19899,9 +19894,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lodash.defaults": {
       "version": "4.2.0",
@@ -20223,13 +20218,13 @@
       }
     },
     "mongoose": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.5.1.tgz",
-      "integrity": "sha512-gJCkUtW3KgAu7Uf8HTVv+S3wf9+xldR5LFYM6mABJJQHQB0aWUGyC3bWsl2X/6dVHZSoQq3wh5UV7rWC4FrewA==",
+      "version": "7.8.9",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.8.9.tgz",
+      "integrity": "sha512-V3GBAJbmOAdzEP8murOvlg7q1szlbe4jTBRyW+JBHRduJBe7F9dk5eyqJDTuYrdBcOOWfLbr6AgXrDK7F0/o5A==",
       "requires": {
-        "bson": "^5.4.0",
+        "bson": "^5.5.0",
         "kareem": "2.5.1",
-        "mongodb": "5.8.1",
+        "mongodb": "5.9.2",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",
@@ -20237,17 +20232,17 @@
       },
       "dependencies": {
         "bson": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-5.4.0.tgz",
-          "integrity": "sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA=="
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
+          "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g=="
         },
         "mongodb": {
-          "version": "5.8.1",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.8.1.tgz",
-          "integrity": "sha512-wKyh4kZvm6NrCPH8AxyzXm3JBoEf4Xulo0aUWh3hCgwgYJxyQ1KLST86ZZaSWdj6/kxYUA3+YZuyADCE61CMSg==",
+          "version": "5.9.2",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
+          "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
           "requires": {
             "@mongodb-js/saslprep": "^1.1.0",
-            "bson": "^5.4.0",
+            "bson": "^5.5.0",
             "mongodb-connection-string-url": "^2.6.0",
             "socks": "^2.7.1"
           }
@@ -20364,7 +20359,7 @@
       "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.21"
+        "lodash": "^4.18.1"
       }
     },
     "node-fetch": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spaship-api",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "description": "SPAship API",
   "author": "Soumyadip Chowdhury",
   "private": true,
@@ -49,7 +49,7 @@
     "fs": "0.0.1-security",
     "js-base64": "^3.7.5",
     "jwt-decode": "^3.1.2",
-    "mongoose": "^7.5.1",
+    "mongoose": "^7.8.4",
     "mongoose-autopopulate": "^1.0.1",
     "multer": "^1.4.5-lts.1",
     "reflect-metadata": "^0.1.13",
@@ -93,6 +93,10 @@
     "ts-node": "^10.0.0",
     "tsconfig-paths": "^3.10.1",
     "typescript": "^4.3.5"
+  },
+  "overrides": {
+    "flatted": "^3.4.2",
+    "lodash": "^4.18.1"
   },
   "jest": {
     "moduleFileExtensions": [


### PR DESCRIPTION
Subject: chore(api) : version updated for the api packages
Assignees: @soumyadip007

## Closes / Fixes

1. package updated for the api


CVE | Package | Vulnerable range | Old version | New version | Fix type
-- | -- | -- | -- | -- | --
CVE-2025-23061 | mongoose | 7.0.0-rc0 – 7.8.3 | ^7.5.1 → resolved 7.x.x | 7.8.9 | Direct dep bump
CVE-2026-33228 | flatted | ≤ 3.4.1 | 3.2.7 (via eslint → file-entry-cache → flat-cache) | 3.4.2 | overrides
CVE-2026-4800 | lodash | ≤ 4.17.23 | 4.17.21 (via @nestjs/config, @nestjs/swagger, eventstore, etc.) | 4.18.1 | overrides

Verification:

- npm audit - none of the three packages appear in vulnerability output
- npm run build - TypeScript compilation succeeds with zero errors
- No existing functionality broken (build clean, same test results as before)

## Does this PR introduce a breaking change

NO

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->

## Screenshot(s)

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

<!-- Add your screenshot(s) below this line -->

</details>

### Ready-for-merge Checklist

- [ ] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Does the change have appropriate unit tests?
- [ ] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [ ] Was this feature demo'd and the design review approved?